### PR TITLE
Feature/conversion entrypoints spike

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Java 17 Maven library; sources live in `src/main/java/berlin/yuna/typemap` with `logic` (converters/encoders), `model` (TypeMap/TypeList + concurrent variants), and `config` (converter registry). Shared resources sit in `src/main/resources`.  
+- Tests reside in `src/test/java` (JUnit Jupiter + AssertJ); sample fixtures can be placed in `src/test/resources`. Build outputs land in `target/`.
+
+## Build, Test, and Development Commands
+- `./mvnw clean verify` – full build, unit tests, and JaCoCo coverage.
+- `./mvnw test` – run test suite only; use `-Dtest=TypeMapTest` to target a class.
+- `./mvnw -DskipTests package` – produce an artifact without executing tests (CI should still run them).
+- `./mvnw install` – publish the library to your local Maven cache for downstream usage.
+- Java 17 toolchain required; prefer running inside the provided Maven wrapper.
+
+## Coding Style & Naming Conventions
+- Four-space indentation, braces on new lines; keep imports explicit and ordered (java.*, javax.*, third-party, project).
+- Favor immutable state: mark fields `final` where possible; avoid shared mutable data and reflection; no parallel streams.
+- Public APIs should never return `null`—use Optionals or empty collections. Keep converters pure and side-effect free.
+- Naming: classes/interfaces in PascalCase, methods/fields in camelCase, constants in UPPER_SNAKE_CASE. Tests mirror class names with `*Test`.
+
+## Testing Guidelines
+- Frameworks: JUnit Jupiter 6, AssertJ. Test discovery matches `**/*Test.java`.
+- Structure tests with Given/When/Then and cover both happy-path conversions and edge cases (nullables, invalid JSON/XML, concurrent maps).
+- Aim for deterministic runs (fixed seeds/Clocks). Generate coverage with `./mvnw jacoco:report` if you need reports locally.
+
+## Commit & Pull Request Guidelines
+- Branch from `main`; use semantic commit messages (`feat:`, `fix:`, `chore:`). Keep commits focused and small.
+- Ensure new code is covered by tests and passes `./mvnw clean verify` before raising a PR.
+- PRs should include a short summary, linked issue, and any relevant screenshots or API notes. Bump versions following semver when publishing.
+- Avoid large refactors without prior discussion; prefer incremental, reviewable changes.

--- a/README.md
+++ b/README.md
@@ -14,27 +14,33 @@
 ![Label][label_shield]
 ![Label][java_version]
 
+## Installation
+
+### Maven
+```xml
+<dependency>
+  <groupId>berlin.yuna</groupId>
+  <artifactId>type-map</artifactId>
+  <version>${type-map.version}</version>
+</dependency>
+```
+
+### Gradle
+```gradle
+implementation("berlin.yuna:type-map:${typeMapVersion}")
+```
+
 ## Introduction
 
 Greetings, Java developer. Are you tired of wrangling primitive type conversions, fighting rogue JSON strings, and
-sacrificing your sanity to reflection-heavy libraries?
-Good news: the TypeMap/TypeList library exists to end this chaos. Designed with performance, simplicity, and GraalVM
-native compatibility in mind, it transforms the art of type management from a dreaded chore to a seamless experience.
-This TypeMap & TypeList library, equipped with the powerful Type-, JSON-, XML-Converter, is engineered to simplify these
-challenges.
-It's designed for developers who seek a hassle-free way to handle diverse data types and conversions, enabling you to
-focus more on business logic rather than boilerplate code.
+sacrificing your sanity to reflection-heavy libraries? Good news: the TypeMap/TypeList library exists to end this chaos.
+Designed with performance, simplicity, and GraalVM native compatibility in mind, it transforms the art of type
+management from a dreaded chore to a seamless experience.
 
 ## Motivation
 
 Most libraries promise ease, but under the hood, they hide performance-draining reflection or endless dependencies. Not
-this one.
-This library was forged from the frustration of clunky, bloated tools. Now, with a clean, lightweight design, you can
-experience true power:
-
-* No Reflection. Ever.
-* Unrivaled Performance for heavy workloads.
-* Endless Extensibility, enabling custom type conversions.
+this one. This library was forged from the frustration of clunky, bloated tools.
 
 ### Benefits
 
@@ -56,237 +62,187 @@ experience true power:
         - [ConcurrentTypeList](src/main/java/berlin/yuna/typemap/model/ConcurrentTypeList.java)
     - [TypeMap](src/main/java/berlin/yuna/typemap/model/TypeMap.java)
         - [LinkedTypeMap](src/main/java/berlin/yuna/typemap/model/LinkedTypeMap.java)
-        - [ConcurrentTypeMap](src/main/java/berlin/yuna/typemap/model/ConcurrentTypeMap.java))
+        - [ConcurrentTypeMap](src/main/java/berlin/yuna/typemap/model/ConcurrentTypeMap.java)
 - Supportive Tools:
     - [TypeConverter](src/main/java/berlin/yuna/typemap/logic/TypeConverter.java)
-    - [JsonEncoder & XmlEncoder](src/main/java/berlin/yuna/typemap/logic/JsonEncoder.java)
-    - [JsonDecoder & XmlDecoder](src/main/java/berlin/yuna/typemap/logic/JsonDecoder.java)
+    - [JsonEncoder](src/main/java/berlin/yuna/typemap/logic/JsonEncoder.java)
+    - [JsonDecoder](src/main/java/berlin/yuna/typemap/logic/JsonDecoder.java)
     - [XmlEncoder](src/main/java/berlin/yuna/typemap/logic/XmlEncoder.java)
     - [XmlDecoder](src/main/java/berlin/yuna/typemap/logic/XmlDecoder.java)
     - [ArgsDecoder](src/main/java/berlin/yuna/typemap/logic/ArgsDecoder.java)
 - Extension Mechanism:
     - [TypeConversionRegister](#register-custom-conversions)
 
-
 ### Getting Started
 
-Let’s flex some muscle.
+Quick start (JSON or XML input):
+```java
+TypeMap map = TypeMap.mapOf(jsonOrXml);
+TypeList list = TypeList.listOf(jsonOrXml);
+```
 
 #### Basics
 ```java
-    TypeMap typeMap = new TypeMap().putR("myTime", new Date());
+TypeMap typeMap = new TypeMap().putR("myTime", new Date());
 OffsetDateTime timeValue = typeMap.asOffsetDateTime("myTime");
-OffsetDateTime timeValue = typeMap.as(OffsetDateTime.class, "myTime");
+OffsetDateTime timeValue2 = typeMap.as(OffsetDateTime.class, "myTime");
 ```
 
 ```java
-    TypeList typeList = new TypeList().addR(new Date());
-OffsetDateTime timeValue = typeMap.asOffsetDateTime(0);
-OffsetDateTime timeValue = typeMap.as(OffsetDateTime.class, 0);
+TypeList typeList = new TypeList().addR(new Date());
+OffsetDateTime timeValue = typeList.asOffsetDateTime(0);
+OffsetDateTime timeValue2 = typeList.as(OffsetDateTime.class, 0);
 ```
 
 #### Collections
 
 ```java
-    TypeMap typeMap = new TypeMap().putR("myKey", new String[]{"1", "2", "3"});
+TypeMap typeMap = new TypeMap().putR("myKey", new String[]{"1", "2", "3"});
 
 TypeList list1 = typeMap.asList("myKey");
-Integer numberThree = typeList.asList("myKey").as(2, Integer.class)
+Integer numberThree = typeMap.asList("myKey").as(2, Integer.class);
 List<Integer> list2 = typeMap.asList(Integer.class, "myKey");
 List<Integer> list3 = typeMap.asList(ArrayList::new, Integer.class, "myKey");
 ```
 
 ```java
-    TypeList typeList = new TypeList().addR(new String[]{"1", "2", "3"});
+TypeList typeList = new TypeList().addR(new String[]{"1", "2", "3"});
 
 TypeList list1 = typeList.asList(0);
-Integer numberThree = typeList.asList(0).asIntList(2)
-List<Integer> list2 = typeList.asIntList(0);
-List<Integer> list3 = typeList.asList(Integer::new, Integer.class, 0);
+Integer numberThree = typeList.asList(0).as(2, Integer.class);
+List<Integer> list2 = typeList.asList(Integer.class, 0);
+List<Integer> list3 = typeList.asList(ArrayList::new, Integer.class, 0);
 ```
 
 #### Maps
 
 ```java
-    TypeMap typeMap = new TypeMap().putR("mykey", Map.of(6, new Date()));
+TypeMap typeMap = new TypeMap().putR("myKey", Map.of(6, new Date()));
 
 LinkedTypeMap map1 = typeMap.asMap("myKey");
-Map<Long, Instant> map2 = typeMap.asMap(Long.class, Instant.class, "mykey")
-Map<Long, Instant> map2 = typeMap.asMap(() -> new HashMap<>(), Long.class, "mykey")
+Map<Long, Instant> map2 = typeMap.asMap(Long.class, Instant.class, "myKey");
+Map<Long, Instant> map3 = typeMap.asMap(HashMap::new, Long.class, Instant.class, "myKey");
 ```
 
 ```java
-    TypeList typeLst = new TypeList().addR(Map.of(6, new Date()));
+TypeList typeList = new TypeList().addR(Map.of(6, new Date()));
 
-LinkedTypeMap map1 = typeLst.asMap(0);
-Map<Long, Instant> map2 = typeLst.asMap(Long.class, Instant.class, 0);
-Map<Long, Instant> map3 = typeLst.asMap(HashMap::new, Long.class, Instant.class, 0);
+LinkedTypeMap map1 = typeList.asMap(0);
+Map<Long, Instant> map2 = typeList.asMap(Long.class, Instant.class, 0);
+Map<Long, Instant> map3 = typeList.asMap(HashMap::new, Long.class, Instant.class, 0);
 ```
 
-#### Json & XML
+#### JSON & XML
 
-_[JsonEncoder](src/main/java/berlin/yuna/typemap/logic/JsonEncoder.java) & [JsonDecoder](src/main/java/berlin/yuna/typemap/logic/JsonDecoder.java)
-is used internally_
+_TypeMap/TypeList use JsonDecoder/XmlDecoder internally; the decoder APIs are meant for advanced use._
 
 ```java
-    final String jsonString =
-    "{\n"
-        + "  \"outerMap\": {\n"
-        + "    \"innerMap\": {\n"
-        + "      \"timestamp\": 1800000000000,\n"
-        + "    },\n"
-        + "    \"myList\": [\"BB\",1,true,null,1.2]\n"
-        + "  }\n"
-        + "}";
+String jsonString = "{"
+    + "\"outerMap\":{"
+    + "\"innerMap\":{\"timestamp\":1800000000000},"
+    + "\"myList\":[\"BB\",1,true,null,1.2]"
+    + "}"
+    + "}";
 
-final TypeMap jsonMap = new TypeMap(jsonString);
-// or xmlTypeOf(xmlString); jsonTypeOf(jsonOrXml); new TypeList(jsonOrXmlString);
+TypeMap jsonMap = TypeMap.mapOf(jsonString);
+LinkedTypeMap inner = jsonMap.asMap("outerMap", "innerMap");
+List<Object> list = jsonMap.asList(Object.class, "outerMap", "myList");
+TestEnum enumValue = jsonMap.as(TestEnum.class, "outerMap", "myList", 0);
+Long timestamp = jsonMap.asLong("outerMap", "innerMap", "timestamp");
+String backToJson = jsonMap.toJson();
+```
 
-final LinkedTypeMap map1 = jsonMap.asMap("outerMap", "innerMap")
-final Map<String, Instant> map2 jsonMap.
+```java
+String xmlString = "<root><id>7</id></root>";
+TypeMap xmlMap = TypeMap.mapOf(xmlString);
+Long id = xmlMap.asLong("id");
+```
 
-asMap(String .class, Instant .class,"outerMap","innerMap")
+#### Streaming JSON (IO-backed streams must be closed)
 
-final TypeList list1 = jsonMap.asMap("outerMap").asList("myList")
-final TypeList list2 = jsonMap.asList("outerMap", "myList")
-final List<Object> list3 = jsonMap.asList(Object.class, "outerMap", "myList")
-final TestEnum enum1 = jsonMap.asMap("outerMap").asList("myList").as(TestEnum.class, 0)
-final TestEnum enum2 = jsonMap.asList("outerMap", "myList").as(TestEnum.class, 0)
-
-final Date myDate = jsonMap.asLong("outerMap", "innerMap", "timestamp");
-final Long myTimestamp = jsonMap.asLong("outerMap", "innerMap", "timestamp");
-final TestEnum myEnum = jsonMap.as(TestEnum.class, "outerMap", "myList", 0);
-final Boolean myBoolean = jsonMap.asBoolean("outerMap", "myList", 2);
-final String backToJson = jsonMap.toJson();
+```java
+try (Stream<Pair<Integer, Object>> stream = JsonDecoder.streamJsonArray(path)) {
+    stream.forEach(pair -> System.out.println(pair.value()));
+}
 ```
 
 #### Args
 
-_[ArgsDecoder](src/main/java/berlin/yuna/typemap/logic/ArgsDecoder.java) is used internally_
+_ArgsDecoder is used internally_
 
 ```java
-final String[] cliArgs = {" myCommand1    myCommand2 --help  -v2=\"true\" -v=\"true\" -v=\"true\" --verbose=\"true\"   -Args=\"true\" -param 42   54   -ArgList=\"item 1\" --ArgList=\"item 2\" -v2=\"false\" --ArgList=\"-item 3\"  "};
-final TypeMap map1 = new TypeMap(cliArgs);
+String[] cliArgs = {"myCommand1", "myCommand2", "--help", "-v2=true", "-param", "42"};
+TypeMap map = new TypeMap(cliArgs);
 
-final Boolean help = map.asBoolean("help");
-final Boolean v = map.asBoolean("v");
-final Boolean v2 = map.asBoolean("v2");
-final Boolean verbose = map.asBoolean("verbose");
-final Boolean args = map.asBoolean("Args");
-final List<Boolean> v2List = map.asList(Boolean.class, "v2")
-final List<Integer> paramList = map.asList(Integer.class, "param");
-final TypeList argList = map.asList("ArgList");
+Boolean help = map.asBoolean("help");
+Boolean v2 = map.asBoolean("v2");
+List<Integer> paramList = map.asList(Integer.class, "param");
 ```
 
 ### TypeConverter
 
-_[TypeConverter](src/main/java/berlin/yuna/typemap/logic/TypeConverter.java) - The `TypeConverter` is the core of
-the `TypeMap`/`TypeList`_
+_TypeConverter is the core of TypeMap/TypeList conversions_
 
 * `TypeConverter.mapOf`
 * `TypeConverter.convertObj`
 * `TypeConverter.collectionOf`
 * `JsonEncoder.toJson`
-* `JsonDecoder.jsonOf`
-* `JsonDecoder.jsonMapOf`
-* `JsonDecoder.jsonListOf`
+* `JsonDecoder.mapOf`
+* `JsonDecoder.listOf`
+* `JsonDecoder.typeOf`
 
 ```java
-
 // ENUM
-final TestEnum enum2 = enumOf("BB", TestEnum.class)
+TestEnum enumValue = enumOf("BB", TestEnum.class);
 
 // OBJECT
-final TestEnum enum1 = convertObj("BB", TestEnum.class)
-final Long long1 = convertObj("1800000000000", Long.class)
-final OffsetDateTime time1 = convertObj("1800000000000", OffsetDateTime.class)
+TestEnum enumValue2 = convertObj("BB", TestEnum.class);
+Long longValue = convertObj("1800000000000", Long.class);
+OffsetDateTime timeValue = convertObj("1800000000000", OffsetDateTime.class);
 
 // MAP
-final TypeMap map1 = mapOf(Map.of("12", "34", "56", "78"))
-final Map<String, Integer> map2 = mapOf(Map.of("12", "34", "56", "78"), String.class, Integer.class)
-final Map<String, Integer> map3 = mapOf(Map.of("12", "34", "56", "78"), () -> new HashMap<>(), String.class, Integer.class)
+TypeMap map1 = mapOf(Map.of("12", "34", "56", "78"));
+Map<String, Integer> map2 = mapOf(Map.of("12", "34", "56", "78"), String.class, Integer.class);
+Map<String, Integer> map3 = mapOf(Map.of("12", "34", "56", "78"), HashMap::new, String.class, Integer.class);
 
 // COLLECTION
-final TypeList list1 = collectionOf(asList("123", "456"))
-final Set<Integer .class>list2=
-
-collectionOf(asList("123","456"),Integer.class)
-final Set<Integer .class>set1=
-
-collectionOf(asList("123","456"),()->new HashSet<>(),Integer .class)
+TypeList list1 = collectionOf(Arrays.asList("123", "456"));
+Set<Integer> list2 = collectionOf(Arrays.asList("123", "456"), Integer.class);
+Set<Integer> set1 = collectionOf(Arrays.asList("123", "456"), HashSet::new, Integer.class);
 ```
-
-### Extension Mechanism
 
 ### Register custom conversions
 
-_[TypeConversionRegister](src/main/java/berlin/yuna/typemap/config/TypeConversionRegister.java) - Exception are ignored
-and results in `null`_
+_Exceptions are ignored and result in `null`_
 
 ```java
-    conversionFrom(String .class).
-
-to(Integer .class).
-
-register(Path::toUri);
-    TypeConversionRegister.
-
-registerTypeConvert(Path .class, File .class, Path::toFile);
-    TypeConversionRegister.
-
-registerTypeConvert(Path .class, URL .class, path->path.
-
-toUri().
-
-toURL());
+conversionFrom(String.class).to(Integer.class).register(Path::toUri);
+TypeConversionRegister.registerTypeConvert(Path.class, File.class, Path::toFile);
+TypeConversionRegister.registerTypeConvert(Path.class, URL.class, path -> path.toUri().toURL());
 ```
 
 [build_shield]: https://github.com/YunaBraska/type-map/workflows/MVN_RELEASE/badge.svg
-
 [build_link]: https://github.com/YunaBraska/type-map/actions?query=workflow%3AMVN_RELEASE
-
 [maintainable_shield]: https://img.shields.io/codeclimate/maintainability/YunaBraska/type-map?style=flat-square
-
 [maintainable_link]: https://codeclimate.com/github/YunaBraska/type-map/maintainability
-
 [coverage_shield]: https://img.shields.io/codeclimate/coverage/YunaBraska/type-map?style=flat-square
-
 [coverage_link]: https://codeclimate.com/github/YunaBraska/type-map/test_coverage
-
 [issues_shield]: https://img.shields.io/github/issues/YunaBraska/type-map?style=flat-square
-
 [issues_link]: https://github.com/YunaBraska/type-map/commits/main
-
 [commit_shield]: https://img.shields.io/github/last-commit/YunaBraska/type-map?style=flat-square
-
 [commit_link]: https://github.com/YunaBraska/type-map/issues
-
 [license_shield]: https://img.shields.io/github/license/YunaBraska/type-map?style=flat-square
-
 [license_link]: https://github.com/YunaBraska/type-map/blob/main/LICENSE
-
 [dependency_shield]: https://img.shields.io/librariesio/github/YunaBraska/type-map?style=flat-square
-
 [dependency_link]: https://libraries.io/github/YunaBraska/type-map
-
 [central_shield]: https://img.shields.io/maven-central/v/berlin.yuna/type-map?style=flat-square
-
 [central_link]:https://search.maven.org/artifact/berlin.yuna/type-map
-
 [tag_shield]: https://img.shields.io/github/v/tag/YunaBraska/type-map?style=flat-square
-
 [tag_link]: https://github.com/YunaBraska/type-map/releases
-
 [javadoc_shield]: https://javadoc.io/badge2/berlin.yuna/type-map/javadoc.svg?style=flat-square
-
 [javadoc_link]: https://javadoc.io/doc/berlin.yuna/type-map
-
 [size_shield]: https://img.shields.io/github/repo-size/YunaBraska/type-map?style=flat-square
-
 [label_shield]: https://img.shields.io/badge/Yuna-QueenInside-blueviolet?style=flat-square
-
 [gitter_shield]: https://img.shields.io/gitter/room/YunaBraska/type-map?style=flat-square
-
 [gitter_link]: https://gitter.im/type-map/Lobby
-
 [java_version]: https://img.shields.io/badge/java-17-blueviolet?style=flat-square

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>berlin.yuna</groupId>
     <artifactId>type-map</artifactId>
-    <version>2025.11.3050708</version>
+    <version>2026.01.0171520</version>
     <packaging>jar</packaging>
 
     <name>type-map</name>
@@ -44,9 +44,9 @@
         <project.reporting.outputEncoding>${project.encoding}</project.reporting.outputEncoding>
 
         <!-- TEST -->
-        <junit.version>6.0.1</junit.version>
+        <junit.version>6.0.2</junit.version>
         <assertj.version>3.27.6</assertj.version>
-        <junit-launcher.version>6.0.1</junit-launcher.version>
+        <junit-launcher.version>6.0.2</junit-launcher.version>
 
         <!-- BUILD -->
         <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>

--- a/src/main/java/berlin/yuna/typemap/logic/ArgsDecoder.java
+++ b/src/main/java/berlin/yuna/typemap/logic/ArgsDecoder.java
@@ -1,28 +1,30 @@
 package berlin.yuna.typemap.logic;
 
+import berlin.yuna.typemap.model.LinkedTypeMap;
 import berlin.yuna.typemap.model.TypeList;
 import berlin.yuna.typemap.model.TypeSet;
 
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import static java.util.Collections.singletonList;
 
 
 public class ArgsDecoder {
 
-    public static Map<String, TypeSet> argsOf(final String input) {
-        final Map<String, TypeSet> result = new HashMap<>();
+    public static LinkedTypeMap argsOf(final String input) {
+        final LinkedTypeMap result = new LinkedTypeMap();
         final List<Integer[]> keyRanges = getKeyRanges(input);
 
         for (int i = 0; i < keyRanges.size(); i++) {
             final Integer[] range = keyRanges.get(i);
             final int offsetEnd = i + 1 < keyRanges.size() ? keyRanges.get(i + 1)[0] : input.length();
             final String key = input.substring(range[0], range[1]);
-            final String cleanKey = key.substring(key.startsWith("--") ? 2 : 1).trim();
+            final String cleanKey = key.substring(key.startsWith("--") ? 2 : 1).strip();
             final String value = input.substring(range[1] + 1, offsetEnd);
-            final TypeSet values = result.computeIfAbsent(cleanKey, v -> new TypeSet());
-            values.addAll((hasText(value) ? handleValue(value.trim()) : singletonList(true)));
+            final TypeSet values = (TypeSet) result.computeIfAbsent(cleanKey, v -> new TypeSet());
+            values.addAll((hasText(value) ? handleValue(value.strip()) : singletonList(true)));
             result.put(cleanKey, values);
         }
         return result;
@@ -36,7 +38,7 @@ public class ArgsDecoder {
         if ((value.startsWith("'") && value.endsWith("'")) || (value.startsWith("\"") && value.endsWith("\""))) {
             return new TypeList().addR(convertToType(value.substring(1, value.length() - 1)));
         }
-        return new TypeList().addAllR(Arrays.stream(value.split("\\s+", -1)).map(ArgsDecoder::convertToType).collect(Collectors.toList()));
+        return new TypeList().addAllR(Arrays.stream(value.split("\\s+", -1)).map(ArgsDecoder::convertToType).toList());
     }
 
     private static Object convertToType(final String string) {

--- a/src/main/java/berlin/yuna/typemap/logic/JsonDecoder.java
+++ b/src/main/java/berlin/yuna/typemap/logic/JsonDecoder.java
@@ -12,29 +12,19 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.PushbackReader;
 import java.io.Reader;
 import java.io.UncheckedIOException;
 import java.io.PushbackInputStream;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Iterator;
-import java.util.Spliterator;
-import java.util.Spliterators;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
-import static berlin.yuna.typemap.logic.JsonEncoder.unescapeJson;
-import static berlin.yuna.typemap.logic.TypeConverter.convertObj;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
-import static java.util.Spliterators.spliteratorUnknownSize;
 
 public class JsonDecoder {
 
@@ -186,57 +176,7 @@ public class JsonDecoder {
      * @return lazy stream of Type elements (caller must close)
      */
     public static Stream<Object> streamArray(final InputStream json, final Charset charset) throws IOException {
-        final LenientStream stream = new LenientStream(new InputStreamReader(json, charset), 8 * 1024);
-        final int start = stream.nextNonWhitespace();
-        if (start != '[') {
-            throw new IllegalStateException("Expected array start '['");
-        }
-
-        final Iterator<Object> iterator = new Iterator<>() {
-            private boolean endReached;
-
-            @Override
-            public boolean hasNext() {
-                if (endReached) {
-                    return false;
-                }
-                try {
-                    final int next = stream.nextNonWhitespace();
-                    if (next == ']') {
-                        endReached = true;
-                        return false;
-                    }
-                    stream.unread(next);
-                    return true;
-                } catch (final IOException e) {
-                    endReached = true;
-                    return false;
-                }
-            }
-
-            @Override
-            public Object next() {
-                if (!hasNext()) {
-                    throw new java.util.NoSuchElementException();
-                }
-                try {
-                    final Object value = parseValue(stream);
-                    final int sep = stream.nextNonWhitespace();
-                    if (sep == ']') {
-                        endReached = true;
-                    } else if (sep != ',') {
-                        throw new IllegalStateException("Invalid array separator");
-                    }
-                    return value;
-                } catch (final IOException e) {
-                    endReached = true;
-                    throw new IllegalStateException(e);
-                }
-            }
-        };
-
-        return StreamSupport.stream(spliteratorUnknownSize(iterator, Spliterator.ORDERED), false)
-                .onClose(() -> closeQuietly(stream.reader));
+        return JsonLenientParser.streamArray(new InputStreamReader(json, charset));
     }
 
     /**
@@ -248,64 +188,7 @@ public class JsonDecoder {
      */
     @SuppressWarnings("java:S3776")
     public static Stream<Pair<String, Object>> streamObject(final InputStream json, final Charset charset) throws IOException {
-        final LenientStream stream = new LenientStream(new InputStreamReader(json, charset), 8 * 1024);
-        final int start = stream.nextNonWhitespace();
-        if (start != '{')
-            throw new IllegalStateException("Expected object start '{'");
-        final Iterator<Pair<String, Object>> iterator = new Iterator<>() {
-            private boolean endReached;
-
-            @Override
-            public boolean hasNext() {
-                if (endReached) {
-                    return false;
-                }
-                try {
-                    final int next = stream.nextNonWhitespace();
-                    if (next == '}') {
-                        endReached = true;
-                        return false;
-                    }
-                    stream.unread(next);
-                    return true;
-                } catch (final IOException e) {
-                    endReached = true;
-                    return false;
-                }
-            }
-
-            @Override
-            public Pair<String, Object> next() {
-                if (!hasNext()) {
-                    throw new java.util.NoSuchElementException();
-                }
-                try {
-                    final int first = stream.nextNonWhitespace();
-                    if (first == '}') {
-                        endReached = true;
-                        return null;
-                    }
-                    final String key = parseKey(stream, first);
-                    final int sep = stream.nextNonWhitespace();
-                    if (sep != ':') {
-                        throw new IllegalStateException("Invalid JSON object separator");
-                    }
-                    final Object value = parseValue(stream);
-                    final int endOrComma = stream.nextNonWhitespace();
-                    if (endOrComma == '}') {
-                        endReached = true;
-                    } else if (endOrComma != ',') {
-                        throw new IllegalStateException("Invalid JSON object separator");
-                    }
-                    return new Pair<>(key, value);
-                } catch (final IOException e) {
-                    endReached = true;
-                    throw new IllegalStateException(e);
-                }
-            }
-        };
-
-        return errorTolerantStream(iterator, () -> closeQuietly(stream.reader));
+        return JsonLenientParser.streamObject(new InputStreamReader(json, charset));
     }
 
     /**
@@ -318,7 +201,7 @@ public class JsonDecoder {
     public static Stream<Pair<Integer, Object>> streamJsonArray(final InputStream json, final Charset charset) {
         try {
             final AtomicInteger index = new AtomicInteger(0);
-            return errorTolerantStream(streamArray(json, charset).map(value -> new Pair<>(index.getAndIncrement(), value)));
+            return JsonLenientParser.errorTolerantStream(streamArray(json, charset).map(value -> new Pair<>(index.getAndIncrement(), value)));
         } catch (final Exception ignored) {
             return Stream.empty();
         }
@@ -350,11 +233,7 @@ public class JsonDecoder {
     public static Stream<Pair<Integer, Object>> streamJsonArray(final Path path, final Charset charset) {
         if (path == null)
             return Stream.empty();
-        try {
-            return streamJsonArray(Files.newInputStream(path), charset);
-        } catch (final IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        return open(() -> Files.newInputStream(path), charset, JsonDecoder::streamJsonArray);
     }
 
     public static Stream<Pair<Integer, Object>> streamJsonArray(final Path path) {
@@ -374,11 +253,7 @@ public class JsonDecoder {
     public static Stream<Pair<Integer, Object>> streamJsonArray(final URI uri, final Charset charset) {
         if (uri == null)
             return Stream.empty();
-        try {
-            return streamJsonArray(uri.toURL(), charset);
-        } catch (final MalformedURLException e) {
-            throw new UncheckedIOException(new IOException(e));
-        }
+        return open(() -> uri.toURL().openStream(), charset, JsonDecoder::streamJsonArray);
     }
 
     public static Stream<Pair<Integer, Object>> streamJsonArray(final URI uri) {
@@ -388,11 +263,7 @@ public class JsonDecoder {
     public static Stream<Pair<Integer, Object>> streamJsonArray(final URL url, final Charset charset) {
         if (url == null)
             return Stream.empty();
-        try {
-            return streamJsonArray(url.openStream(), charset);
-        } catch (final IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        return open(url::openStream, charset, JsonDecoder::streamJsonArray);
     }
 
     public static Stream<Pair<Integer, Object>> streamJsonArray(final URL url) {
@@ -404,7 +275,7 @@ public class JsonDecoder {
      */
     public static Stream<Pair<String, Object>> streamJsonObject(final InputStream json, final Charset charset) {
         try {
-            return errorTolerantStream(streamObject(json, charset));
+            return streamObject(json, charset);
         } catch (final Exception ignored) {
             return Stream.empty();
         }
@@ -436,11 +307,7 @@ public class JsonDecoder {
     public static Stream<Pair<String, Object>> streamJsonObject(final Path path, final Charset charset) {
         if (path == null)
             return Stream.empty();
-        try {
-            return streamJsonObject(Files.newInputStream(path), charset);
-        } catch (final IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        return open(() -> Files.newInputStream(path), charset, JsonDecoder::streamJsonObject);
     }
 
     public static Stream<Pair<String, Object>> streamJsonObject(final Path path) {
@@ -460,11 +327,7 @@ public class JsonDecoder {
     public static Stream<Pair<String, Object>> streamJsonObject(final URI uri, final Charset charset) {
         if (uri == null)
             return Stream.empty();
-        try {
-            return streamJsonObject(uri.toURL(), charset);
-        } catch (final MalformedURLException e) {
-            throw new UncheckedIOException(new IOException(e));
-        }
+        return open(() -> uri.toURL().openStream(), charset, JsonDecoder::streamJsonObject);
     }
 
     public static Stream<Pair<String, Object>> streamJsonObject(final URI uri) {
@@ -474,11 +337,7 @@ public class JsonDecoder {
     public static Stream<Pair<String, Object>> streamJsonObject(final URL url, final Charset charset) {
         if (url == null)
             return Stream.empty();
-        try {
-            return streamJsonObject(url.openStream(), charset);
-        } catch (final IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        return open(url::openStream, charset, JsonDecoder::streamJsonObject);
     }
 
     public static Stream<Pair<String, Object>> streamJsonObject(final URL url) {
@@ -501,7 +360,7 @@ public class JsonDecoder {
             final PushbackInputStream pushback = json instanceof final PushbackInputStream p ? p : new PushbackInputStream(json, 1);
             final int ch = nextNonWhitespace(pushback);
             if (ch == -1) {
-                closeQuietly(pushback);
+                JsonLenientParser.closeQuietly(pushback);
                 return Stream.empty();
             }
             pushback.unread(ch);
@@ -510,13 +369,13 @@ public class JsonDecoder {
                     return (Stream<Pair<Object, Object>>) (Stream<?>) streamJsonObject(pushback, charset);
                 if (ch == '[')
                     return (Stream<Pair<Object, Object>>) (Stream<?>) streamJsonArray(pushback, charset);
-                closeQuietly(pushback);
+                JsonLenientParser.closeQuietly(pushback);
                 throw new UncheckedIOException(new IOException("Unsupported top-level token: " + (char) ch));
             } catch (final UncheckedIOException e) {
-                closeQuietly(pushback);
+                JsonLenientParser.closeQuietly(pushback);
                 throw e;
             } catch (final Exception e) {
-                closeQuietly(pushback);
+                JsonLenientParser.closeQuietly(pushback);
                 throw new UncheckedIOException(new IOException(e));
             }
         } catch (final IOException e) {
@@ -569,11 +428,7 @@ public class JsonDecoder {
         if (path == null) {
             return Stream.empty();
         }
-        try {
-            return streamJson(Files.newInputStream(path), charset);
-        } catch (final IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        return open(() -> Files.newInputStream(path), charset, JsonDecoder::streamJson);
     }
 
     /**
@@ -607,11 +462,7 @@ public class JsonDecoder {
         if (uri == null) {
             return Stream.empty();
         }
-        try {
-            return streamJson(uri.toURL(), charset);
-        } catch (final MalformedURLException e) {
-            throw new UncheckedIOException(new IOException(e));
-        }
+        return open(() -> uri.toURL().openStream(), charset, JsonDecoder::streamJson);
     }
 
     /**
@@ -627,11 +478,7 @@ public class JsonDecoder {
     public static Stream<Pair<Object, Object>> streamJson(final URL url, final Charset charset) {
         if (url == null)
             return Stream.empty();
-        try {
-            return streamJson(url.openStream(), charset);
-        } catch (final IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        return open(url::openStream, charset, JsonDecoder::streamJson);
     }
 
     /**
@@ -641,9 +488,40 @@ public class JsonDecoder {
         return streamJson(url, UTF_8);
     }
 
+    public interface InputSupplier {
+        InputStream open() throws IOException;
+    }
+
+    public interface StreamFactory<T> {
+        Stream<T> open(InputStream input, Charset charset) throws IOException;
+    }
+
+    public static <T> Stream<T> open(final InputSupplier supplier, final Charset charset, final StreamFactory<T> factory) {
+        if (supplier == null) {
+            return Stream.empty();
+        }
+        try {
+            return open(supplier.open(), charset, factory);
+        } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public static <T> Stream<T> open(final InputStream input, final Charset charset, final StreamFactory<T> factory) {
+        if (input == null) {
+            return Stream.empty();
+        }
+        try {
+            return factory.open(input, charset);
+        } catch (final IOException e) {
+            JsonLenientParser.closeQuietly(input);
+            throw new UncheckedIOException(e);
+        }
+    }
+
     /**
      * Detects whether the input stream is XML (leading '<') or JSON and delegates to the appropriate parser.
-     * Uses streaming to avoid buffering whole payloads; wraps incoming streams in a {@link BufferedInputStream} if needed.
+     * Uses streaming to avoid buffering whole payloads; wraps incoming streams in a {@link PushbackInputStream}.
      *
      * @param input   stream to parse
      * @param charset charset to use when decoding JSON content
@@ -664,60 +542,8 @@ public class JsonDecoder {
                 return XmlDecoder.xmlTypeOf(pushback);
             }
             try (final Reader reader = buffered(new InputStreamReader(pushback, charset))) {
-                return parse(reader);
+                return JsonLenientParser.parse(reader);
             }
-        }
-    }
-
-    private static void closeQuietly(final AutoCloseable closeable) {
-        if (closeable != null) {
-            try {
-                closeable.close();
-            } catch (final Exception ignored) {
-                // ignore
-            }
-        }
-    }
-
-    private static <T> Stream<T> errorTolerantStream(final Iterator<T> iterator, final Runnable onClose) {
-        final Spliterator<T> spliterator = new Spliterators.AbstractSpliterator<>(Long.MAX_VALUE, Spliterator.ORDERED) {
-            @Override
-            public boolean tryAdvance(final Consumer<? super T> action) {
-                try {
-                    if (iterator.hasNext()) {
-                        action.accept(iterator.next());
-                        return true;
-                    }
-                    return false;
-                } catch (final Exception e) {
-                    throw new UncheckedIOException(new IOException(e));
-                }
-            }
-        };
-        return StreamSupport.stream(spliterator, false).onClose(onClose);
-    }
-
-    private static <T> Stream<T> errorTolerantStream(final Stream<T> input) {
-        try {
-            return errorTolerantStream(input.iterator(), input::close);
-        } catch (final Exception ignored) {
-            closeQuietly(input);
-            return Stream.empty();
-        }
-    }
-
-    private static Object parse(final Reader reader) throws IOException {
-        final LenientStream stream = new LenientStream(reader, 8 * 1024);
-        try {
-            final Object value = parseValue(stream);
-            if (value instanceof final LinkedTypeMap singleMap && singleMap.size() == 1 && singleMap.containsKey(""))
-                return singleMap.get("");
-            if (value instanceof final LinkedTypeMap map && map.isEmpty() && "{}".contentEquals(stream.rawText().strip()))
-                return null;
-            return value;
-        } catch (final RuntimeException ignored) {
-            final String raw = stream.rawText();
-            return raw.isEmpty() ? null : raw;
         }
     }
 
@@ -731,221 +557,6 @@ public class JsonDecoder {
             ch = input.read();
         } while (ch != -1 && Character.isWhitespace(ch));
         return ch;
-    }
-
-    private static Object parseValue(final LenientStream stream) throws IOException {
-        final int ch = stream.nextNonWhitespace();
-        if (ch == -1) {
-            return null;
-        }
-        return switch (ch) {
-            case '{' -> parseObject(stream);
-            case '[' -> parseArray(stream);
-            case '"' -> parseString(stream);
-            default -> parsePrimitive(stream, (char) ch);
-        };
-    }
-
-    @SuppressWarnings("java:S3776")
-    private static LinkedTypeMap parseObject(final LenientStream stream) throws IOException {
-        final LinkedTypeMap map = new LinkedTypeMap();
-        while (true) {
-            final int first = stream.nextNonWhitespace();
-            if (first == '}') {
-                return map;
-            } else if (first == -1) {
-                throw new IllegalStateException("Unterminated object");
-            }
-            final String key = parseKey(stream, first);
-            final int separator = stream.nextNonWhitespace();
-            if (separator == ':') {
-                final Object value = parseValue(stream);
-                map.put(key, value);
-                final int sep = stream.nextNonWhitespace();
-                if (sep == '}') {
-                    return map;
-                } else if (sep != ',') {
-                    throw new IllegalStateException("Invalid JSON object separator");
-                }
-            } else if (separator == '}' || separator == ',') {
-                map.put("", key);
-                if (separator == '}') {
-                    return map;
-                }
-            } else {
-                throw new IllegalStateException("Invalid JSON object separator");
-            }
-        }
-    }
-
-    private static String parseKey(final LenientStream stream, final int first) throws IOException {
-        if (first == '"') {
-            return parseString(stream);
-        }
-        final StringBuilder token = new StringBuilder();
-        token.append((char) first);
-        while (true) {
-            final int ch = stream.read();
-            if (ch == -1) {
-                return token.toString();
-            }
-            if (ch == ':') {
-                stream.unread(ch);
-                return token.toString();
-            }
-            if (!Character.isWhitespace(ch)) {
-                token.append((char) ch);
-            }
-        }
-    }
-
-    private static TypeList parseArray(final LenientStream stream) throws IOException {
-        final TypeList list = new TypeList();
-        while (true) {
-            int ch = stream.nextNonWhitespace();
-            if (ch == ']') {
-                return list;
-            }
-            if (ch == -1) {
-                throw new IllegalStateException("Unterminated array");
-            }
-            stream.unread(ch);
-            list.add(parseValue(stream));
-            ch = stream.nextNonWhitespace();
-            if (ch == ']') {
-                return list;
-            } else if (ch != ',') {
-                throw new IllegalStateException("Invalid JSON array separator");
-            }
-        }
-    }
-
-    private static String parseString(final LenientStream stream) throws IOException {
-        final StringBuilder sb = new StringBuilder();
-        boolean escaped = false;
-        while (true) {
-            final int ch = stream.read();
-            if (ch == -1) {
-                throw new IllegalStateException("Unterminated string");
-            }
-            if (escaped) {
-                sb.append(decodeEscape(ch, stream));
-                escaped = false;
-            } else if (ch == '\\') {
-                escaped = true;
-            } else if (ch == '"') {
-                break;
-            } else {
-                sb.append((char) ch);
-            }
-        }
-        return sb.toString();
-    }
-
-    private static char decodeEscape(final int esc, final LenientStream stream) throws IOException {
-        return switch (esc) {
-            case '"' -> '"';
-            case '\\' -> '\\';
-            case '/' -> '/';
-            case 'b' -> '\b';
-            case 'f' -> '\f';
-            case 'n' -> '\n';
-            case 'r' -> '\r';
-            case 't' -> '\t';
-            case 'u' -> {
-                final char[] hex = new char[4];
-                for (int i = 0; i < 4; i++) {
-                    final int h = stream.read();
-                    if (h == -1) {
-                        throw new IllegalStateException("Incomplete unicode escape");
-                    }
-                    hex[i] = (char) h;
-                }
-                yield (char) Integer.parseInt(new String(hex), 16);
-            }
-            default -> (char) esc;
-        };
-    }
-
-    private static Object parsePrimitive(final LenientStream stream, final char first) throws IOException {
-        final StringBuilder token = new StringBuilder();
-        token.append(first);
-        while (true) {
-            final int ch = stream.read();
-            if (ch == -1 || ch == ',' || ch == '}' || ch == ']' || Character.isWhitespace(ch)) {
-                if (ch != -1) {
-                    stream.unread(ch);
-                }
-                break;
-            }
-            token.append((char) ch);
-        }
-        final String value = token.toString();
-        return switch (value) {
-            case "true" -> true;
-            case "false" -> false;
-            case "null" -> null;
-            default -> convertToPrimitive(value);
-        };
-    }
-
-    private static Object convertToPrimitive(final String value) {
-        if ("null".equals(value)) {
-            return null;
-        } else if ("true".equals(value) || "false".equals(value)) {
-            return Boolean.parseBoolean(value);
-        } else {
-            final Object result;
-            if (value.contains(".") || value.contains("e") || value.contains("E")) {
-                result = convertObj(value, Double.class);
-            } else {
-                result = convertObj(value, Long.class);
-            }
-            return result == null ? unescapeJson(value) : result;
-        }
-    }
-
-    private static class LenientStream {
-        private static final int PUSHBACK_SIZE = 16;
-        private final PushbackReader reader;
-        private final StringBuilder raw;
-        private final int rawLimit;
-
-        LenientStream(final Reader reader, final int rawLimit) {
-            this.reader = new PushbackReader(reader, PUSHBACK_SIZE);
-            this.rawLimit = rawLimit;
-            this.raw = new StringBuilder(Math.min(rawLimit, 1024));
-        }
-
-        int read() throws IOException {
-            final int ch = reader.read();
-            appendRaw(ch);
-            return ch;
-        }
-
-        void unread(final int ch) throws IOException {
-            if (ch != -1) {
-                reader.unread(ch);
-            }
-        }
-
-        int nextNonWhitespace() throws IOException {
-            int ch;
-            do {
-                ch = read();
-            } while (ch != -1 && Character.isWhitespace(ch));
-            return ch;
-        }
-
-        String rawText() {
-            return raw.toString();
-        }
-
-        private void appendRaw(final int ch) {
-            if (ch != -1 && raw.length() < rawLimit) {
-                raw.append((char) ch);
-            }
-        }
     }
 
     private JsonDecoder() {

--- a/src/main/java/berlin/yuna/typemap/logic/JsonDecoder.java
+++ b/src/main/java/berlin/yuna/typemap/logic/JsonDecoder.java
@@ -61,31 +61,40 @@ public class JsonDecoder {
     }
 
     /**
-     * Parses JSON into a {@link LinkedTypeMap}, auto-detecting XML if provided.
+     * Parses JSON or XML into a {@link LinkedTypeMap}.
+     * For JSON objects, the map contains the object entries.
+     * For JSON arrays, XML, or primitive values, the map contains a single entry with key "" and the parsed value.
+     * Returns an empty map when input is null, blank, or cannot be parsed.
      */
-    public static LinkedTypeMap jsonMapOf(final String json) {
-        if (json == null)
+    public static LinkedTypeMap mapOf(final String jsonOrXml) {
+        if (jsonOrXml == null)
             return new LinkedTypeMap();
-        try (final ByteArrayInputStream in = new ByteArrayInputStream(json.getBytes(UTF_8))) {
-            return jsonMapOf(in, UTF_8);
+        try (final ByteArrayInputStream in = new ByteArrayInputStream(jsonOrXml.getBytes(UTF_8))) {
+            return mapOf(in, UTF_8);
         } catch (final IOException ignored) {
             return new LinkedTypeMap();
         }
     }
 
     /**
-     * Parses JSON into a {@link LinkedTypeMap}, auto-detecting XML if provided.
+     * Parses JSON or XML into a {@link LinkedTypeMap}.
+     * For JSON objects, the map contains the object entries.
+     * For JSON arrays, XML, or primitive values, the map contains a single entry with key "" and the parsed value.
+     * Returns an empty map when input is null or cannot be parsed.
      */
-    public static LinkedTypeMap jsonMapOf(final InputStream json) {
-        return jsonMapOf(json, UTF_8);
+    public static LinkedTypeMap mapOf(final InputStream jsonOrXml) {
+        return mapOf(jsonOrXml, UTF_8);
     }
 
     /**
-     * Parses JSON into a {@link LinkedTypeMap} using the provided charset, auto-detecting XML if provided.
+     * Parses JSON or XML into a {@link LinkedTypeMap} using the provided charset for JSON content.
+     * For JSON objects, the map contains the object entries.
+     * For JSON arrays, XML, or primitive values, the map contains a single entry with key "" and the parsed value.
+     * Returns an empty map when input is null or cannot be parsed.
      */
-    public static LinkedTypeMap jsonMapOf(final InputStream json, final Charset charset) {
+    public static LinkedTypeMap mapOf(final InputStream jsonOrXml, final Charset charset) {
         try {
-            final Object result = detectAndParse(json, charset);
+            final Object result = detectAndParse(jsonOrXml, charset);
             if (result instanceof final LinkedTypeMap map) {
                 return map;
             } else if (result != null) {
@@ -98,32 +107,41 @@ public class JsonDecoder {
     }
 
     /**
-     * Parses JSON into a {@link TypeList}, auto-detecting XML if provided.
+     * Parses JSON or XML into a {@link TypeList}.
+     * For JSON arrays or XML, returns the parsed list.
+     * For JSON objects or primitive values, returns a list containing the parsed value.
+     * Returns an empty list when input is null, blank, or cannot be parsed.
      */
-    public static TypeList jsonListOf(final String json) {
-        if (json == null) {
+    public static TypeList listOf(final String jsonOrXml) {
+        if (jsonOrXml == null) {
             return new TypeList();
         }
-        try (final ByteArrayInputStream in = new ByteArrayInputStream(json.getBytes(UTF_8))) {
-            return jsonListOf(in, UTF_8);
+        try (final ByteArrayInputStream in = new ByteArrayInputStream(jsonOrXml.getBytes(UTF_8))) {
+            return listOf(in, UTF_8);
         } catch (final IOException ignored) {
             return new TypeList();
         }
     }
 
     /**
-     * Parses JSON into a {@link TypeList}, auto-detecting XML if provided.
+     * Parses JSON or XML into a {@link TypeList}.
+     * For JSON arrays or XML, returns the parsed list.
+     * For JSON objects or primitive values, returns a list containing the parsed value.
+     * Returns an empty list when input is null or cannot be parsed.
      */
-    public static TypeList jsonListOf(final InputStream json) {
-        return jsonListOf(json, UTF_8);
+    public static TypeList listOf(final InputStream jsonOrXml) {
+        return listOf(jsonOrXml, UTF_8);
     }
 
     /**
-     * Parses JSON into a {@link TypeList} using the provided charset, auto-detecting XML if provided.
+     * Parses JSON or XML into a {@link TypeList} using the provided charset for JSON content.
+     * For JSON arrays or XML, returns the parsed list.
+     * For JSON objects or primitive values, returns a list containing the parsed value.
+     * Returns an empty list when input is null or cannot be parsed.
      */
-    public static TypeList jsonListOf(final InputStream json, final Charset charset) {
+    public static TypeList listOf(final InputStream jsonOrXml, final Charset charset) {
         try {
-            final Object result = detectAndParse(json, charset);
+            final Object result = detectAndParse(jsonOrXml, charset);
             if (result instanceof final TypeList list) {
                 return list;
             } else if (result instanceof final LinkedTypeMap map) {
@@ -135,6 +153,247 @@ public class JsonDecoder {
             // fallthrough
         }
         return new TypeList();
+    }
+
+    /**
+     * Parses JSON or XML CharSequence into a {@link LinkedTypeMap}.
+     * JSON objects become map entries; arrays, XML, and primitive values are wrapped under the "" key.
+     * Returns an empty map when input is null, blank, or cannot be parsed.
+     */
+    public static LinkedTypeMap mapOf(final CharSequence jsonOrXml) {
+        return jsonOrXml == null ? new LinkedTypeMap() : mapOf(jsonOrXml.toString());
+    }
+
+    /**
+     * Parses JSON or XML CharSequence into a {@link TypeList}.
+     * JSON arrays and XML return the parsed list; objects and primitive values are wrapped into a single-item list.
+     * Returns an empty list when input is null, blank, or cannot be parsed.
+     */
+    public static TypeList listOf(final CharSequence jsonOrXml) {
+        return jsonOrXml == null ? new TypeList() : listOf(jsonOrXml.toString());
+    }
+
+    /**
+     * Parses JSON or XML file into a {@link LinkedTypeMap}.
+     * JSON objects become map entries; arrays, XML, and primitive values are wrapped under the "" key.
+     * Uses the provided charset for JSON content. Returns an empty map when input is null or cannot be parsed.
+     */
+    public static LinkedTypeMap mapOf(final Path jsonOrXml, final Charset charset) {
+        if (jsonOrXml == null) {
+            return new LinkedTypeMap();
+        }
+        try (InputStream in = Files.newInputStream(jsonOrXml)) {
+            return mapOf(in, charset);
+        } catch (final IOException ignored) {
+            return new LinkedTypeMap();
+        }
+    }
+
+    public static LinkedTypeMap mapOf(final Path jsonOrXml) {
+        return mapOf(jsonOrXml, UTF_8);
+    }
+
+    /**
+     * Parses JSON or XML file into a {@link TypeList}.
+     * JSON arrays and XML return the parsed list; objects and primitive values are wrapped into a single-item list.
+     * Uses the provided charset for JSON content. Returns an empty list when input is null or cannot be parsed.
+     */
+    public static TypeList listOf(final Path jsonOrXml, final Charset charset) {
+        if (jsonOrXml == null) {
+            return new TypeList();
+        }
+        try (InputStream in = Files.newInputStream(jsonOrXml)) {
+            return listOf(in, charset);
+        } catch (final IOException ignored) {
+            return new TypeList();
+        }
+    }
+
+    /**
+     * Parses JSON or XML file into a {@link TypeList}.
+     * JSON arrays and XML return the parsed list; objects and primitive values are wrapped into a single-item list.
+     * Returns an empty list when input is null or cannot be parsed.
+     */
+    public static TypeList listOf(final Path jsonOrXml) {
+        return listOf(jsonOrXml, UTF_8);
+    }
+
+    /**
+     * Parses JSON or XML file into a {@link LinkedTypeMap}.
+     * JSON objects become map entries; arrays, XML, and primitive values are wrapped under the "" key.
+     * Uses the provided charset for JSON content. Returns an empty map when input is null or cannot be parsed.
+     */
+    public static LinkedTypeMap mapOf(final File jsonOrXml, final Charset charset) {
+        return jsonOrXml == null ? new LinkedTypeMap() : mapOf(jsonOrXml.toPath(), charset);
+    }
+
+    /**
+     * Parses JSON or XML file into a {@link LinkedTypeMap}.
+     * JSON objects become map entries; arrays, XML, and primitive values are wrapped under the "" key.
+     * Returns an empty map when input is null or cannot be parsed.
+     */
+    public static LinkedTypeMap mapOf(final File jsonOrXml) {
+        return mapOf(jsonOrXml, UTF_8);
+    }
+
+    /**
+     * Parses JSON or XML file into a {@link TypeList}.
+     * JSON arrays and XML return the parsed list; objects and primitive values are wrapped into a single-item list.
+     * Uses the provided charset for JSON content. Returns an empty list when input is null or cannot be parsed.
+     */
+    public static TypeList listOf(final File jsonOrXml, final Charset charset) {
+        return jsonOrXml == null ? new TypeList() : listOf(jsonOrXml.toPath(), charset);
+    }
+
+    /**
+     * Parses JSON or XML file into a {@link TypeList}.
+     * JSON arrays and XML return the parsed list; objects and primitive values are wrapped into a single-item list.
+     * Returns an empty list when input is null or cannot be parsed.
+     */
+    public static TypeList listOf(final File jsonOrXml) {
+        return listOf(jsonOrXml, UTF_8);
+    }
+
+    /**
+     * Parses JSON or XML URI into a {@link LinkedTypeMap}.
+     * JSON objects become map entries; arrays, XML, and primitive values are wrapped under the "" key.
+     * Uses the provided charset for JSON content. Returns an empty map when input is null or cannot be parsed.
+     */
+    public static LinkedTypeMap mapOf(final URI jsonOrXml, final Charset charset) {
+        if (jsonOrXml == null) {
+            return new LinkedTypeMap();
+        }
+        try (InputStream in = jsonOrXml.toURL().openStream()) {
+            return mapOf(in, charset);
+        } catch (final IOException ignored) {
+            return new LinkedTypeMap();
+        }
+    }
+
+    /**
+     * Parses JSON or XML URI into a {@link LinkedTypeMap}.
+     * JSON objects become map entries; arrays, XML, and primitive values are wrapped under the "" key.
+     * Returns an empty map when input is null or cannot be parsed.
+     */
+    public static LinkedTypeMap mapOf(final URI jsonOrXml) {
+        return mapOf(jsonOrXml, UTF_8);
+    }
+
+    /**
+     * Parses JSON or XML URI into a {@link TypeList}.
+     * JSON arrays and XML return the parsed list; objects and primitive values are wrapped into a single-item list.
+     * Uses the provided charset for JSON content. Returns an empty list when input is null or cannot be parsed.
+     */
+    public static TypeList listOf(final URI jsonOrXml, final Charset charset) {
+        if (jsonOrXml == null) {
+            return new TypeList();
+        }
+        try (InputStream in = jsonOrXml.toURL().openStream()) {
+            return listOf(in, charset);
+        } catch (final IOException ignored) {
+            return new TypeList();
+        }
+    }
+
+    /**
+     * Parses JSON or XML URI into a {@link TypeList}.
+     * JSON arrays and XML return the parsed list; objects and primitive values are wrapped into a single-item list.
+     * Returns an empty list when input is null or cannot be parsed.
+     */
+    public static TypeList listOf(final URI jsonOrXml) {
+        return listOf(jsonOrXml, UTF_8);
+    }
+
+    /**
+     * Parses JSON or XML URL into a {@link LinkedTypeMap}.
+     * JSON objects become map entries; arrays, XML, and primitive values are wrapped under the "" key.
+     * Uses the provided charset for JSON content. Returns an empty map when input is null or cannot be parsed.
+     */
+    public static LinkedTypeMap mapOf(final URL jsonOrXml, final Charset charset) {
+        if (jsonOrXml == null) {
+            return new LinkedTypeMap();
+        }
+        try (InputStream in = jsonOrXml.openStream()) {
+            return mapOf(in, charset);
+        } catch (final IOException ignored) {
+            return new LinkedTypeMap();
+        }
+    }
+
+    /**
+     * Parses JSON or XML URL into a {@link LinkedTypeMap}.
+     * JSON objects become map entries; arrays, XML, and primitive values are wrapped under the "" key.
+     * Returns an empty map when input is null or cannot be parsed.
+     */
+    public static LinkedTypeMap mapOf(final URL jsonOrXml) {
+        return mapOf(jsonOrXml, UTF_8);
+    }
+
+    /**
+     * Parses JSON or XML URL into a {@link TypeList}.
+     * JSON arrays and XML return the parsed list; objects and primitive values are wrapped into a single-item list.
+     * Uses the provided charset for JSON content. Returns an empty list when input is null or cannot be parsed.
+     */
+    public static TypeList listOf(final URL jsonOrXml, final Charset charset) {
+        if (jsonOrXml == null) {
+            return new TypeList();
+        }
+        try (InputStream in = jsonOrXml.openStream()) {
+            return listOf(in, charset);
+        } catch (final IOException ignored) {
+            return new TypeList();
+        }
+    }
+
+    /**
+     * Parses JSON or XML URL into a {@link TypeList}.
+     * JSON arrays and XML return the parsed list; objects and primitive values are wrapped into a single-item list.
+     * Returns an empty list when input is null or cannot be parsed.
+     */
+    public static TypeList listOf(final URL jsonOrXml) {
+        return listOf(jsonOrXml, UTF_8);
+    }
+
+    /**
+     * Alias for {@link #mapOf(String)}.
+     */
+    public static LinkedTypeMap jsonMapOf(final String json) {
+        return mapOf(json);
+    }
+
+    /**
+     * Alias for {@link #mapOf(InputStream)}.
+     */
+    public static LinkedTypeMap jsonMapOf(final InputStream json) {
+        return mapOf(json, UTF_8);
+    }
+
+    /**
+     * Alias for {@link #mapOf(InputStream, Charset)}.
+     */
+    public static LinkedTypeMap jsonMapOf(final InputStream json, final Charset charset) {
+        return mapOf(json, charset);
+    }
+
+    /**
+     * Alias for {@link #listOf(String)}.
+     */
+    public static TypeList jsonListOf(final String json) {
+        return listOf(json);
+    }
+
+    /**
+     * Alias for {@link #listOf(InputStream)}.
+     */
+    public static TypeList jsonListOf(final InputStream json) {
+        return listOf(json, UTF_8);
+    }
+
+    /**
+     * Alias for {@link #listOf(InputStream, Charset)}.
+     */
+    public static TypeList jsonListOf(final InputStream json, final Charset charset) {
+        return listOf(json, charset);
     }
 
     public static Object jsonOf(final String json) {

--- a/src/main/java/berlin/yuna/typemap/logic/JsonDecoder.java
+++ b/src/main/java/berlin/yuna/typemap/logic/JsonDecoder.java
@@ -244,13 +244,13 @@ public class JsonDecoder {
      * @return lazy stream of entries (caller must close)
      * @throws IOException when the stream cannot be read or the payload is not an object
      */
-    public static Stream<Pair<Object, Object>> streamObject(final InputStream json, final Charset charset) throws IOException {
+    public static Stream<Pair<String, Object>> streamObject(final InputStream json, final Charset charset) throws IOException {
         final LenientStream stream = new LenientStream(new InputStreamReader(json, charset), 8 * 1024);
         final int start = stream.nextNonWhitespace();
         if (start != '{') {
             throw new IllegalStateException("Expected object start '{'");
         }
-        final Iterator<Pair<Object, Object>> iterator = new Iterator<>() {
+        final Iterator<Pair<String, Object>> iterator = new Iterator<>() {
             private boolean endReached;
 
             @Override
@@ -273,7 +273,7 @@ public class JsonDecoder {
             }
 
             @Override
-            public Pair<Object, Object> next() {
+            public Pair<String, Object> next() {
                 if (!hasNext()) {
                     throw new java.util.NoSuchElementException();
                 }
@@ -316,7 +316,7 @@ public class JsonDecoder {
      * @return lazy stream of pairs (caller must close)
      * @throws IOException when the stream cannot be read or is empty
      */
-    public static Stream<Pair<Object, Object>> streamJson(final InputStream json, final Charset charset) throws IOException {
+    public static Stream<Pair<String, Object>> streamJson(final InputStream json, final Charset charset) throws IOException {
         if (json == null)
             return Stream.empty();
         final BufferedInputStream buffered = json instanceof final BufferedInputStream b ? b : new BufferedInputStream(json);
@@ -334,7 +334,8 @@ public class JsonDecoder {
             return streamObject(buffered, charset);
         if (ch == '[') {
             final AtomicInteger index = new AtomicInteger(0);
-            return streamArray(buffered, charset).map(type -> new Pair<>(index.getAndIncrement(), type == null ? null : type.value()));
+            return streamArray(buffered, charset)
+                .map(type -> new Pair<>(String.valueOf(index.getAndIncrement()), type == null ? null : type.value()));
         }
         throw new IllegalStateException("Expected JSON object or array");
     }
@@ -342,14 +343,14 @@ public class JsonDecoder {
     /**
      * Streams a JSON object or array as {@link Pair} entries using UTF-8.
      */
-    public static Stream<Pair<Object, Object>> streamJson(final InputStream json) throws IOException {
+    public static Stream<Pair<String, Object>> streamJson(final InputStream json) throws IOException {
         return streamJson(json, UTF_8);
     }
 
     /**
      * Streams a JSON object or array from a {@link String} with the provided charset.
      */
-    public static Stream<Pair<Object, Object>> streamJson(final String json, final Charset charset) throws IOException {
+    public static Stream<Pair<String, Object>> streamJson(final String json, final Charset charset) throws IOException {
         if (json == null) {
             return Stream.empty();
         }
@@ -359,28 +360,28 @@ public class JsonDecoder {
     /**
      * Streams a JSON object or array from a {@link String} using UTF-8.
      */
-    public static Stream<Pair<Object, Object>> streamJson(final String json) throws IOException {
+    public static Stream<Pair<String, Object>> streamJson(final String json) throws IOException {
         return streamJson(json, UTF_8);
     }
 
     /**
      * Streams a JSON object or array from a {@link CharSequence} with the provided charset.
      */
-    public static Stream<Pair<Object, Object>> streamJson(final CharSequence json, final Charset charset) throws IOException {
+    public static Stream<Pair<String, Object>> streamJson(final CharSequence json, final Charset charset) throws IOException {
         return json == null ? Stream.empty() : streamJson(json.toString(), charset);
     }
 
     /**
      * Streams a JSON object or array from a {@link CharSequence} using UTF-8.
      */
-    public static Stream<Pair<Object, Object>> streamJson(final CharSequence json) throws IOException {
+    public static Stream<Pair<String, Object>> streamJson(final CharSequence json) throws IOException {
         return streamJson(json, UTF_8);
     }
 
     /**
      * Streams a JSON object or array from a {@link Path} with the provided charset.
      */
-    public static Stream<Pair<Object, Object>> streamJson(final Path path, final Charset charset) throws IOException {
+    public static Stream<Pair<String, Object>> streamJson(final Path path, final Charset charset) throws IOException {
         if (path == null) {
             return Stream.empty();
         }
@@ -390,14 +391,14 @@ public class JsonDecoder {
     /**
      * Streams a JSON object or array from a {@link Path} using UTF-8.
      */
-    public static Stream<Pair<Object, Object>> streamJson(final Path path) throws IOException {
+    public static Stream<Pair<String, Object>> streamJson(final Path path) throws IOException {
         return streamJson(path, UTF_8);
     }
 
     /**
      * Streams a JSON object or array from a {@link File} with the provided charset.
      */
-    public static Stream<Pair<Object, Object>> streamJson(final File file, final Charset charset) throws IOException {
+    public static Stream<Pair<String, Object>> streamJson(final File file, final Charset charset) throws IOException {
         if (file == null) {
             return Stream.empty();
         }
@@ -407,14 +408,14 @@ public class JsonDecoder {
     /**
      * Streams a JSON object or array from a {@link File} using UTF-8.
      */
-    public static Stream<Pair<Object, Object>> streamJson(final File file) throws IOException {
+    public static Stream<Pair<String, Object>> streamJson(final File file) throws IOException {
         return streamJson(file, UTF_8);
     }
 
     /**
      * Streams a JSON object or array from a {@link URI} with the provided charset.
      */
-    public static Stream<Pair<Object, Object>> streamJson(final URI uri, final Charset charset) throws IOException {
+    public static Stream<Pair<String, Object>> streamJson(final URI uri, final Charset charset) throws IOException {
         if (uri == null) {
             return Stream.empty();
         }
@@ -424,14 +425,14 @@ public class JsonDecoder {
     /**
      * Streams a JSON object or array from a {@link URI} using UTF-8.
      */
-    public static Stream<Pair<Object, Object>> streamJson(final URI uri) throws IOException {
+    public static Stream<Pair<String, Object>> streamJson(final URI uri) throws IOException {
         return streamJson(uri, UTF_8);
     }
 
     /**
      * Streams a JSON object or array from a {@link URL} with the provided charset.
      */
-    public static Stream<Pair<Object, Object>> streamJson(final URL url, final Charset charset) throws IOException {
+    public static Stream<Pair<String, Object>> streamJson(final URL url, final Charset charset) throws IOException {
         if (url == null)
             return Stream.empty();
         return streamJson(url.openStream(), charset);
@@ -440,7 +441,7 @@ public class JsonDecoder {
     /**
      * Streams a JSON object or array from a {@link URL} using UTF-8.
      */
-    public static Stream<Pair<Object, Object>> streamJson(final URL url) throws IOException {
+    public static Stream<Pair<String, Object>> streamJson(final URL url) throws IOException {
         return streamJson(url, UTF_8);
     }
 

--- a/src/main/java/berlin/yuna/typemap/logic/JsonDecoder.java
+++ b/src/main/java/berlin/yuna/typemap/logic/JsonDecoder.java
@@ -87,14 +87,14 @@ public class JsonDecoder {
      * @return A Map, List, or Object representing the JSON structure.
      */
     public static Object jsonOf(final String json) {
-        final String input = json == null ? null : json.trim();
+        final String input = json == null ? null : json.strip();
         if (json == null || json.equals("{}")) {
             return null;
         } else if (input.startsWith("{") && input.endsWith("}")) {
-            final LinkedTypeMap map = toMap(removeWrapper(input).trim());
+            final LinkedTypeMap map = toMap(removeWrapper(input).strip());
             return map.size() == 1 && map.containsKey("") ? map.get("") : map;
         } else if (input.startsWith("[") && input.endsWith("]")) {
-            return toList(removeWrapper(input).trim());
+            return toList(removeWrapper(input).strip());
         } else if (input.startsWith("\"") && input.endsWith("\"")) {
             return unescapeJson(input.substring(1, input.length() - 1));
         } else {
@@ -129,8 +129,8 @@ public class JsonDecoder {
             if (keyValue.length < 2) {
                 map.put("", jsonOf(pair));
             } else {
-                final String key = unquote(keyValue[0].trim());
-                final Object value = jsonOf(keyValue[1].trim());
+                final String key = unquote(keyValue[0].strip());
+                final Object value = jsonOf(keyValue[1].strip());
                 map.put(key, value);
             }
         }
@@ -180,8 +180,8 @@ public class JsonDecoder {
     private static String[] splitFirstBy(final String string, final char c) {
         final int colonIndex = firstNonEscapedCar(string, c);
         return colonIndex == -1 ? new String[0] : new String[]{
-            string.substring(0, colonIndex).trim(),
-            string.substring(colonIndex + 1).trim()
+            string.substring(0, colonIndex).strip(),
+            string.substring(colonIndex + 1).strip()
         };
     }
 
@@ -201,7 +201,7 @@ public class JsonDecoder {
     private static TypeList toList(final String json) {
         final TypeList list = new TypeList();
         for (final String element : splitJson(json)) {
-            list.add(jsonOf(element.trim())); // Recursively parse each element
+            list.add(jsonOf(element.strip())); // Recursively parse each element
         }
         return list;
     }

--- a/src/main/java/berlin/yuna/typemap/logic/JsonDecoder.java
+++ b/src/main/java/berlin/yuna/typemap/logic/JsonDecoder.java
@@ -354,48 +354,6 @@ public class JsonDecoder {
         return listOf(jsonOrXml, UTF_8);
     }
 
-    /**
-     * Alias for {@link #mapOf(String)}.
-     */
-    public static LinkedTypeMap jsonMapOf(final String json) {
-        return mapOf(json);
-    }
-
-    /**
-     * Alias for {@link #mapOf(InputStream)}.
-     */
-    public static LinkedTypeMap jsonMapOf(final InputStream json) {
-        return mapOf(json, UTF_8);
-    }
-
-    /**
-     * Alias for {@link #mapOf(InputStream, Charset)}.
-     */
-    public static LinkedTypeMap jsonMapOf(final InputStream json, final Charset charset) {
-        return mapOf(json, charset);
-    }
-
-    /**
-     * Alias for {@link #listOf(String)}.
-     */
-    public static TypeList jsonListOf(final String json) {
-        return listOf(json);
-    }
-
-    /**
-     * Alias for {@link #listOf(InputStream)}.
-     */
-    public static TypeList jsonListOf(final InputStream json) {
-        return listOf(json, UTF_8);
-    }
-
-    /**
-     * Alias for {@link #listOf(InputStream, Charset)}.
-     */
-    public static TypeList jsonListOf(final InputStream json, final Charset charset) {
-        return listOf(json, charset);
-    }
-
     public static Object jsonOf(final String json) {
         if (json == null) {
             return null;

--- a/src/main/java/berlin/yuna/typemap/logic/JsonLenientParser.java
+++ b/src/main/java/berlin/yuna/typemap/logic/JsonLenientParser.java
@@ -1,0 +1,406 @@
+package berlin.yuna.typemap.logic;
+
+import berlin.yuna.typemap.model.LinkedTypeMap;
+import berlin.yuna.typemap.model.Pair;
+import berlin.yuna.typemap.model.TypeList;
+
+import java.io.IOException;
+import java.io.PushbackReader;
+import java.io.Reader;
+import java.io.UncheckedIOException;
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static berlin.yuna.typemap.logic.JsonEncoder.unescapeJson;
+import static berlin.yuna.typemap.logic.TypeConverter.convertObj;
+import static java.util.Spliterators.spliteratorUnknownSize;
+
+public class JsonLenientParser {
+
+    public static Object parse(final Reader reader) throws IOException {
+        final LenientStream stream = new LenientStream(reader, 8 * 1024);
+        try {
+            final Object value = parseValue(stream);
+            if (value instanceof final LinkedTypeMap singleMap && singleMap.size() == 1 && singleMap.containsKey(""))
+                return singleMap.get("");
+            if (value instanceof final LinkedTypeMap map && map.isEmpty() && "{}".contentEquals(stream.rawText().strip()))
+                return null;
+            return value;
+        } catch (final RuntimeException ignored) {
+            final String raw = stream.rawText();
+            return raw.isEmpty() ? null : raw;
+        }
+    }
+
+    public static Stream<Object> streamArray(final Reader reader) throws IOException {
+        final LenientStream stream = new LenientStream(reader, 8 * 1024);
+        final int start = stream.nextNonWhitespace();
+        if (start != '[') {
+            throw new IllegalStateException("Expected array start '['");
+        }
+
+        final Iterator<Object> iterator = new Iterator<>() {
+            private boolean endReached;
+
+            @Override
+            public boolean hasNext() {
+                if (endReached) {
+                    return false;
+                }
+                try {
+                    final int next = stream.nextNonWhitespace();
+                    if (next == ']') {
+                        endReached = true;
+                        return false;
+                    }
+                    stream.unread(next);
+                    return true;
+                } catch (final IOException e) {
+                    endReached = true;
+                    return false;
+                }
+            }
+
+            @Override
+            public Object next() {
+                if (!hasNext()) {
+                    throw new java.util.NoSuchElementException();
+                }
+                try {
+                    final Object value = parseValue(stream);
+                    final int sep = stream.nextNonWhitespace();
+                    if (sep == ']') {
+                        endReached = true;
+                    } else if (sep != ',') {
+                        throw new IllegalStateException("Invalid array separator");
+                    }
+                    return value;
+                } catch (final IOException e) {
+                    endReached = true;
+                    throw new IllegalStateException(e);
+                }
+            }
+        };
+
+        return StreamSupport.stream(spliteratorUnknownSize(iterator, Spliterator.ORDERED), false)
+            .onClose(() -> closeQuietly(stream.reader));
+    }
+
+    @SuppressWarnings("java:S3776")
+    public static Stream<Pair<String, Object>> streamObject(final Reader reader) throws IOException {
+        final LenientStream stream = new LenientStream(reader, 8 * 1024);
+        final int start = stream.nextNonWhitespace();
+        if (start != '{')
+            throw new IllegalStateException("Expected object start '{'");
+        final Iterator<Pair<String, Object>> iterator = new Iterator<>() {
+            private boolean endReached;
+
+            @Override
+            public boolean hasNext() {
+                if (endReached) {
+                    return false;
+                }
+                try {
+                    final int next = stream.nextNonWhitespace();
+                    if (next == '}') {
+                        endReached = true;
+                        return false;
+                    }
+                    stream.unread(next);
+                    return true;
+                } catch (final IOException e) {
+                    endReached = true;
+                    return false;
+                }
+            }
+
+            @Override
+            public Pair<String, Object> next() {
+                if (!hasNext()) {
+                    throw new java.util.NoSuchElementException();
+                }
+                try {
+                    final int first = stream.nextNonWhitespace();
+                    if (first == '}') {
+                        endReached = true;
+                        return null;
+                    }
+                    final String key = parseKey(stream, first);
+                    final int sep = stream.nextNonWhitespace();
+                    if (sep != ':') {
+                        throw new IllegalStateException("Invalid JSON object separator");
+                    }
+                    final Object value = parseValue(stream);
+                    final int endOrComma = stream.nextNonWhitespace();
+                    if (endOrComma == '}') {
+                        endReached = true;
+                    } else if (endOrComma != ',') {
+                        throw new IllegalStateException("Invalid JSON object separator");
+                    }
+                    return new Pair<>(key, value);
+                } catch (final IOException e) {
+                    endReached = true;
+                    throw new IllegalStateException(e);
+                }
+            }
+        };
+
+        return errorTolerantStream(iterator, () -> closeQuietly(stream.reader));
+    }
+
+    public static <T> Stream<T> errorTolerantStream(final Iterator<T> iterator, final Runnable onClose) {
+        final Spliterator<T> spliterator = new Spliterators.AbstractSpliterator<>(Long.MAX_VALUE, Spliterator.ORDERED) {
+            @Override
+            public boolean tryAdvance(final Consumer<? super T> action) {
+                try {
+                    if (iterator.hasNext()) {
+                        action.accept(iterator.next());
+                        return true;
+                    }
+                    return false;
+                } catch (final Exception e) {
+                    throw new UncheckedIOException(new IOException(e));
+                }
+            }
+        };
+        return StreamSupport.stream(spliterator, false).onClose(onClose);
+    }
+
+    public static <T> Stream<T> errorTolerantStream(final Stream<T> input) {
+        try {
+            return errorTolerantStream(input.iterator(), input::close);
+        } catch (final Exception ignored) {
+            closeQuietly(input);
+            return Stream.empty();
+        }
+    }
+
+    public static Object parseValue(final LenientStream stream) throws IOException {
+        final int ch = stream.nextNonWhitespace();
+        if (ch == -1) {
+            return null;
+        }
+        return switch (ch) {
+            case '{' -> parseObject(stream);
+            case '[' -> parseArray(stream);
+            case '"' -> parseString(stream);
+            default -> parsePrimitive(stream, (char) ch);
+        };
+    }
+
+    @SuppressWarnings("java:S3776")
+    public static LinkedTypeMap parseObject(final LenientStream stream) throws IOException {
+        final LinkedTypeMap map = new LinkedTypeMap();
+        while (true) {
+            final int first = stream.nextNonWhitespace();
+            if (first == '}') {
+                return map;
+            } else if (first == -1) {
+                throw new IllegalStateException("Unterminated object");
+            }
+            final String key = parseKey(stream, first);
+            final int separator = stream.nextNonWhitespace();
+            if (separator == ':') {
+                final Object value = parseValue(stream);
+                map.put(key, value);
+                final int sep = stream.nextNonWhitespace();
+                if (sep == '}') {
+                    return map;
+                } else if (sep != ',') {
+                    throw new IllegalStateException("Invalid JSON object separator");
+                }
+            } else if (separator == '}' || separator == ',') {
+                map.put("", key);
+                if (separator == '}') {
+                    return map;
+                }
+            } else {
+                throw new IllegalStateException("Invalid JSON object separator");
+            }
+        }
+    }
+
+    public static String parseKey(final LenientStream stream, final int first) throws IOException {
+        if (first == '"') {
+            return parseString(stream);
+        }
+        final StringBuilder token = new StringBuilder();
+        token.append((char) first);
+        while (true) {
+            final int ch = stream.read();
+            if (ch == -1) {
+                return token.toString();
+            }
+            if (ch == ':') {
+                stream.unread(ch);
+                return token.toString();
+            }
+            if (!Character.isWhitespace(ch)) {
+                token.append((char) ch);
+            }
+        }
+    }
+
+    public static TypeList parseArray(final LenientStream stream) throws IOException {
+        final TypeList list = new TypeList();
+        while (true) {
+            int ch = stream.nextNonWhitespace();
+            if (ch == ']') {
+                return list;
+            }
+            if (ch == -1) {
+                throw new IllegalStateException("Unterminated array");
+            }
+            stream.unread(ch);
+            list.add(parseValue(stream));
+            ch = stream.nextNonWhitespace();
+            if (ch == ']') {
+                return list;
+            } else if (ch != ',') {
+                throw new IllegalStateException("Invalid JSON array separator");
+            }
+        }
+    }
+
+    public static String parseString(final LenientStream stream) throws IOException {
+        final StringBuilder sb = new StringBuilder();
+        boolean escaped = false;
+        while (true) {
+            final int ch = stream.read();
+            if (ch == -1) {
+                throw new IllegalStateException("Unterminated string");
+            }
+            if (escaped) {
+                sb.append(decodeEscape(ch, stream));
+                escaped = false;
+            } else if (ch == '\\') {
+                escaped = true;
+            } else if (ch == '"') {
+                break;
+            } else {
+                sb.append((char) ch);
+            }
+        }
+        return sb.toString();
+    }
+
+    public static char decodeEscape(final int esc, final LenientStream stream) throws IOException {
+        return switch (esc) {
+            case '"' -> '"';
+            case '\\' -> '\\';
+            case '/' -> '/';
+            case 'b' -> '\b';
+            case 'f' -> '\f';
+            case 'n' -> '\n';
+            case 'r' -> '\r';
+            case 't' -> '\t';
+            case 'u' -> {
+                final char[] hex = new char[4];
+                for (int i = 0; i < 4; i++) {
+                    final int h = stream.read();
+                    if (h == -1) {
+                        throw new IllegalStateException("Incomplete unicode escape");
+                    }
+                    hex[i] = (char) h;
+                }
+                yield (char) Integer.parseInt(new String(hex), 16);
+            }
+            default -> (char) esc;
+        };
+    }
+
+    public static Object parsePrimitive(final LenientStream stream, final char first) throws IOException {
+        final StringBuilder token = new StringBuilder();
+        token.append(first);
+        while (true) {
+            final int ch = stream.read();
+            if (ch == -1 || ch == ',' || ch == '}' || ch == ']' || Character.isWhitespace(ch)) {
+                if (ch != -1) {
+                    stream.unread(ch);
+                }
+                break;
+            }
+            token.append((char) ch);
+        }
+        final String value = token.toString();
+        return switch (value) {
+            case "true" -> true;
+            case "false" -> false;
+            case "null" -> null;
+            default -> convertToPrimitive(value);
+        };
+    }
+
+    public static Object convertToPrimitive(final String value) {
+        if ("null".equals(value)) {
+            return null;
+        } else if ("true".equals(value) || "false".equals(value)) {
+            return Boolean.parseBoolean(value);
+        } else {
+            final Object result;
+            if (value.contains(".") || value.contains("e") || value.contains("E")) {
+                result = convertObj(value, Double.class);
+            } else {
+                result = convertObj(value, Long.class);
+            }
+            return result == null ? unescapeJson(value) : result;
+        }
+    }
+
+    public static void closeQuietly(final AutoCloseable closeable) {
+        if (closeable != null) {
+            try {
+                closeable.close();
+            } catch (final Exception ignored) {
+                // ignore
+            }
+        }
+    }
+
+    public static class LenientStream {
+        private static final int PUSHBACK_SIZE = 16;
+        private final PushbackReader reader;
+        private final StringBuilder raw;
+        private final int rawLimit;
+
+        public LenientStream(final Reader reader, final int rawLimit) {
+            this.reader = new PushbackReader(reader, PUSHBACK_SIZE);
+            this.rawLimit = rawLimit;
+            this.raw = new StringBuilder(Math.min(rawLimit, 1024));
+        }
+
+        public int read() throws IOException {
+            final int ch = reader.read();
+            appendRaw(ch);
+            return ch;
+        }
+
+        public void unread(final int ch) throws IOException {
+            if (ch != -1) {
+                reader.unread(ch);
+            }
+        }
+
+        public int nextNonWhitespace() throws IOException {
+            int ch;
+            do {
+                ch = read();
+            } while (ch != -1 && Character.isWhitespace(ch));
+            return ch;
+        }
+
+        public String rawText() {
+            return raw.toString();
+        }
+
+        private void appendRaw(final int ch) {
+            if (ch != -1 && raw.length() < rawLimit) {
+                raw.append((char) ch);
+            }
+        }
+    }
+}

--- a/src/main/java/berlin/yuna/typemap/logic/XmlDecoder.java
+++ b/src/main/java/berlin/yuna/typemap/logic/XmlDecoder.java
@@ -167,8 +167,8 @@ public class XmlDecoder {
             } else if (item.getNodeType() == Node.TEXT_NODE) {
                 // Process value
                 final String text = item.getTextContent();
-                if (i == 0 || hasText(text))
-                    result.add(text != null ? text.trim() : "");
+                if (hasText(text))
+                    result.add(text.strip());
             }
         }
     }
@@ -177,4 +177,3 @@ public class XmlDecoder {
         // static util class
     }
 }
-

--- a/src/main/java/berlin/yuna/typemap/logic/XmlDecoder.java
+++ b/src/main/java/berlin/yuna/typemap/logic/XmlDecoder.java
@@ -9,11 +9,17 @@ import org.xml.sax.SAXParseException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.InputStream;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamReader;
+import java.io.*;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import static berlin.yuna.typemap.logic.ArgsDecoder.hasText;
 
@@ -30,6 +36,8 @@ public class XmlDecoder {
      * @return a {@code TypeList} representing the XML structure, or an empty {@code TypeList} if parsing fails.
      */
     public static TypeList xmlTypeOf(final File xml) {
+        if (xml == null)
+            return new TypeList();
         try (final InputStream fileStream = Files.newInputStream(xml.toPath())) {
             return xmlTypeOf(fileStream);
         } catch (final Exception ignored) {
@@ -44,8 +52,12 @@ public class XmlDecoder {
      * @return a {@code TypeList} representing the XML structure, or an empty {@code TypeList} if parsing fails.
      */
     public static TypeList xmlTypeOf(final InputStream xml) {
-        try {
-            return toTypeMap(documentBuilder().parse(xml));
+        if (xml == null)
+            return new TypeList();
+        try (final Stream<Pair<String, Object>> stream = streamXmlObject(xml)) {
+            final TypeList result = new TypeList();
+            stream.forEach(result::add);
+            return result;
         } catch (final Exception ignored) {
             return new TypeList();
         }
@@ -58,11 +70,9 @@ public class XmlDecoder {
      * @return a {@code TypeList} representing the XML structure, or an empty {@code TypeList} if parsing fails.
      */
     public static TypeList xmlTypeOf(final String xml) {
-        try {
-            return toTypeMap(documentBuilder().parse(new ByteArrayInputStream(xml.getBytes(Charset.defaultCharset()))));
-        } catch (final Exception ignored) {
+        if (xml == null)
             return new TypeList();
-        }
+        return xmlTypeOf(new ByteArrayInputStream(xml.getBytes(Charset.defaultCharset())));
     }
 
     /**
@@ -169,6 +179,200 @@ public class XmlDecoder {
                 final String text = item.getTextContent();
                 if (hasText(text))
                     result.add(text.strip());
+            }
+        }
+    }
+
+    /**
+     * Streams top-level XML elements as key/value pairs without materializing a DOM.
+     *
+     * @param xml     input stream containing XML
+     * @param charset optional charset override (otherwise XML prolog/UTF-8 is used)
+     * @return stream of top-level element pairs
+     */
+    public static Stream<Pair<String, Object>> streamXmlObject(final InputStream xml, final Charset charset) {
+        if (xml == null)
+            return Stream.empty();
+        final var reader = charset == null
+            ? XmlStreams.reader(xml)
+            : XmlStreams.reader(new InputStreamReader(xml, charset));
+
+        final IteratorIterator iterator = new IteratorIterator(reader);
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED | Spliterator.NONNULL), false)
+            .onClose(() -> XmlStreams.closeQuietly(reader));
+    }
+
+    public static Stream<Pair<String, Object>> streamXmlObject(final InputStream xml) {
+        return streamXmlObject(xml, null);
+    }
+
+    public static Stream<Pair<String, Object>> streamXmlObject(final String xml) {
+        return streamXmlObject(xml, Charset.defaultCharset());
+    }
+
+    public static Stream<Pair<String, Object>> streamXmlObject(final CharSequence xml, final Charset charset) {
+        if (xml == null || xml.toString().isBlank())
+            return Stream.empty();
+        return streamXmlObject(new ByteArrayInputStream(xml.toString().getBytes(charset)), charset);
+    }
+
+    public static Stream<Pair<String, Object>> streamXmlObject(final CharSequence xml) {
+        return streamXmlObject(xml, Charset.defaultCharset());
+    }
+
+    public static Stream<Pair<String, Object>> streamXmlObject(final File xml, final Charset charset) {
+        try {
+            return streamXmlObject(Files.newInputStream(xml.toPath()), charset);
+        } catch (final Exception e) {
+            throw new UncheckedIOException(new IOException(e));
+        }
+    }
+
+    public static Stream<Pair<String, Object>> streamXmlObject(final File xml) {
+        return streamXmlObject(xml, Charset.defaultCharset());
+    }
+
+    public static Stream<Pair<String, Object>> streamXmlObject(final java.nio.file.Path xml, final Charset charset) {
+        try {
+            return streamXmlObject(Files.newInputStream(xml), charset);
+        } catch (final Exception e) {
+            throw new UncheckedIOException(new IOException(e));
+        }
+    }
+
+    public static Stream<Pair<String, Object>> streamXmlObject(final java.nio.file.Path xml) {
+        return streamXmlObject(xml, Charset.defaultCharset());
+    }
+
+    public static Stream<Pair<String, Object>> streamXmlObject(final java.net.URI xml, final Charset charset) {
+        try {
+            return streamXmlObject(xml.toURL(), charset);
+        } catch (final Exception e) {
+            throw new UncheckedIOException(new IOException(e));
+        }
+    }
+
+    public static Stream<Pair<String, Object>> streamXmlObject(final java.net.URI xml) {
+        return streamXmlObject(xml, Charset.defaultCharset());
+    }
+
+    public static Stream<Pair<String, Object>> streamXmlObject(final java.net.URL xml, final Charset charset) {
+        try {
+            return streamXmlObject(xml.openStream(), charset);
+        } catch (final Exception e) {
+            throw new UncheckedIOException(new IOException(e));
+        }
+    }
+
+    public static Stream<Pair<String, Object>> streamXmlObject(final java.net.URL xml) {
+        return streamXmlObject(xml, Charset.defaultCharset());
+    }
+
+    private static class IteratorIterator implements java.util.Iterator<Pair<String, Object>> {
+        private final XMLStreamReader reader;
+        private final Deque<ElementFrame> stack = new ArrayDeque<>();
+        private Pair<String, Object> next;
+        private boolean finished;
+
+        IteratorIterator(final XMLStreamReader reader) {
+            this.reader = reader;
+            advance();
+        }
+
+        @Override
+        public boolean hasNext() {
+            return next != null;
+        }
+
+        @Override
+        public Pair<String, Object> next() {
+            final Pair<String, Object> current = next;
+            advance();
+            return current;
+        }
+
+        private void advance() {
+            if (finished) {
+                next = null;
+                return;
+            }
+            try {
+                while (reader.hasNext()) {
+                    final int event = reader.next();
+                    if (event == javax.xml.stream.XMLStreamConstants.START_ELEMENT) {
+                        final ElementFrame frame = new ElementFrame(reader.getLocalName());
+                        for (int i = 0; i < reader.getAttributeCount(); i++) {
+                            frame.content.add(new Pair<>("@" + reader.getAttributeLocalName(i), reader.getAttributeValue(i)));
+                        }
+                        stack.push(frame);
+                    } else if (event == javax.xml.stream.XMLStreamConstants.CHARACTERS || event == javax.xml.stream.XMLStreamConstants.CDATA) {
+                        if (!stack.isEmpty()) {
+                            stack.peek().text.append(reader.getText());
+                        }
+                    } else if (event == javax.xml.stream.XMLStreamConstants.END_ELEMENT) {
+                        final ElementFrame frame = stack.pop();
+                        final String text = frame.text.toString().trim();
+                        if (hasText(text))
+                            frame.content.add(text);
+
+                        final Pair<String, Object> completed = new Pair<>(frame.name, frame.content);
+                        if (stack.isEmpty()) {
+                            next = completed;
+                            return;
+                        }
+                        stack.peek().content.add(completed);
+                    }
+                }
+                finished = true;
+                next = null;
+            } catch (final Exception e) {
+                finished = true;
+                throw new UncheckedIOException(new IOException(e));
+            }
+        }
+    }
+
+    private static class ElementFrame {
+        final String name;
+        final TypeList content = new TypeList();
+        final StringBuilder text = new StringBuilder();
+
+        ElementFrame(final String name) {
+            this.name = name;
+        }
+    }
+
+    private static final class XmlStreams {
+        private static XMLStreamReader reader(final InputStream in) {
+            return createReader(factory(), in);
+        }
+
+        private static XMLStreamReader reader(final InputStreamReader in) {
+            return createReader(factory(), in);
+        }
+
+        private static XMLInputFactory factory() {
+            final XMLInputFactory factory = XMLInputFactory.newInstance();
+            factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+            factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+            return factory;
+        }
+
+        private static XMLStreamReader createReader(final XMLInputFactory factory, final Object source) {
+            try {
+                return source instanceof final InputStream input
+                    ? factory.createXMLStreamReader(input)
+                    : factory.createXMLStreamReader((InputStreamReader) source);
+            } catch (final Exception e) {
+                throw new UncheckedIOException(new IOException(e));
+            }
+        }
+
+        private static void closeQuietly(final XMLStreamReader reader) {
+            try {
+                reader.close();
+            } catch (final Exception ignored) {
+                // ignored
             }
         }
     }

--- a/src/main/java/berlin/yuna/typemap/logic/XmlEncoder.java
+++ b/src/main/java/berlin/yuna/typemap/logic/XmlEncoder.java
@@ -56,9 +56,21 @@ public class XmlEncoder {
             final TypeList content = new TypeList((Collection<?>) first.getValue());
             return toXml(java.util.Collections.singletonList(new Pair<>(first.getKey(), content)));
         }
-        final TypeList entries = new TypeList();
-        map.forEach((key, value) -> entries.add(new Pair<>(String.valueOf(key), value)));
-        return toXml(java.util.Collections.singletonList(new Pair<>("root", entries)));
+        if (first == null) {
+            return "";
+        }
+        final TypeList content = new TypeList();
+        final Object rootValue = first.getValue();
+        if (rootValue instanceof final Collection<?> collection) {
+            content.addAll(collection);
+        } else if (rootValue != null) {
+            content.add(rootValue);
+        }
+        while (iterator.hasNext()) {
+            final Map.Entry<Object, Object> entry = iterator.next();
+            content.add(new Pair<>(String.valueOf(entry.getKey()), entry.getValue()));
+        }
+        return toXml(java.util.Collections.singletonList(new Pair<>(String.valueOf(first.getKey()), content)));
     }
 
     public static String toXml(final TypeList list) {

--- a/src/main/java/berlin/yuna/typemap/logic/XmlEncoder.java
+++ b/src/main/java/berlin/yuna/typemap/logic/XmlEncoder.java
@@ -106,6 +106,11 @@ public class XmlEncoder {
                     }
                 }
             }
+        } else {
+            final String text = TypeConverter.convertObj(value, String.class);
+            if (hasText(text)) {
+                parentElement.setTextContent(text);
+            }
         }
     }
 

--- a/src/main/java/berlin/yuna/typemap/logic/XmlEncoder.java
+++ b/src/main/java/berlin/yuna/typemap/logic/XmlEncoder.java
@@ -52,7 +52,7 @@ public class XmlEncoder {
         }
         final java.util.Iterator<Map.Entry<Object, Object>> iterator = map.entrySet().iterator();
         final Map.Entry<Object, Object> first = iterator.hasNext() ? iterator.next() : null;
-        if (first != null && first.getKey() instanceof String && first.getValue() instanceof Collection<?>) {
+        if (first != null && map.size() == 1 && first.getKey() instanceof String && first.getValue() instanceof Collection<?>) {
             final TypeList content = new TypeList((Collection<?>) first.getValue());
             return toXml(java.util.Collections.singletonList(new Pair<>(first.getKey(), content)));
         }

--- a/src/main/java/berlin/yuna/typemap/model/ConcurrentTypeList.java
+++ b/src/main/java/berlin/yuna/typemap/model/ConcurrentTypeList.java
@@ -28,7 +28,7 @@ public class ConcurrentTypeList extends CopyOnWriteArrayList<Object> implements 
      * Constructs a new {@link ConcurrentTypeList} of the specified json.
      */
     public ConcurrentTypeList(final String json) {
-        this(JsonDecoder.jsonListOf(json));
+        this(JsonDecoder.listOf(json));
     }
 
     /**

--- a/src/main/java/berlin/yuna/typemap/model/ConcurrentTypeMap.java
+++ b/src/main/java/berlin/yuna/typemap/model/ConcurrentTypeMap.java
@@ -29,7 +29,7 @@ public class ConcurrentTypeMap extends ConcurrentHashMap<Object, Object> impleme
      * Constructs a new {@link ConcurrentTypeMap} of the specified json.
      */
     public ConcurrentTypeMap(final String json) {
-        this(JsonDecoder.jsonMapOf(json));
+        this(JsonDecoder.mapOf(json));
     }
 
     /**

--- a/src/main/java/berlin/yuna/typemap/model/ConcurrentTypeSet.java
+++ b/src/main/java/berlin/yuna/typemap/model/ConcurrentTypeSet.java
@@ -28,7 +28,7 @@ public class ConcurrentTypeSet extends CopyOnWriteArrayList<Object> implements T
      * Constructs a new {@link ConcurrentTypeSet} of the specified json.
      */
     public ConcurrentTypeSet(final String json) {
-        this(JsonDecoder.jsonListOf(json));
+        this(JsonDecoder.listOf(json));
     }
 
     /**

--- a/src/main/java/berlin/yuna/typemap/model/LinkedTypeMap.java
+++ b/src/main/java/berlin/yuna/typemap/model/LinkedTypeMap.java
@@ -29,7 +29,7 @@ public class LinkedTypeMap extends LinkedHashMap<Object, Object> implements Type
      * Constructs a new {@link LinkedTypeMap} of the specified json.
      */
     public LinkedTypeMap(final String json) {
-        this(JsonDecoder.jsonMapOf(json));
+        this(JsonDecoder.mapOf(json));
     }
 
     /**

--- a/src/main/java/berlin/yuna/typemap/model/Pair.java
+++ b/src/main/java/berlin/yuna/typemap/model/Pair.java
@@ -48,7 +48,7 @@ public class Pair<K, V> implements Map.Entry<K, V>, TypeInfo<Pair<K, V>> {
     /**
      * Converts key and value into a new {@link Pair} using the provided target types.
      */
-    public <NK, NV> Pair<NK, NV> to(final Class<? extends NK> keyType, final Class<? extends NV> valueType) {
+    public <C, R> Pair<C, R> to(final Class<? extends C> keyType, final Class<? extends R> valueType) {
         return new Pair<>(convertObj(key, keyType), convertObj(value, valueType));
     }
 

--- a/src/main/java/berlin/yuna/typemap/model/Pair.java
+++ b/src/main/java/berlin/yuna/typemap/model/Pair.java
@@ -45,7 +45,10 @@ public class Pair<K, V> implements Map.Entry<K, V>, TypeInfo<Pair<K, V>> {
         return convertObj(value, type);
     }
 
-    public Pair<K, V> to(final Class<K> keyType, final Class<V> valueType) {
+    /**
+     * Converts key and value into a new {@link Pair} using the provided target types.
+     */
+    public <NK, NV> Pair<NK, NV> to(final Class<? extends NK> keyType, final Class<? extends NV> valueType) {
         return new Pair<>(convertObj(key, keyType), convertObj(value, valueType));
     }
 

--- a/src/main/java/berlin/yuna/typemap/model/Pair.java
+++ b/src/main/java/berlin/yuna/typemap/model/Pair.java
@@ -1,16 +1,15 @@
 package berlin.yuna.typemap.model;
 
-import java.util.AbstractMap;
+import berlin.yuna.typemap.logic.JsonEncoder;
+
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import static berlin.yuna.typemap.logic.JsonEncoder.toJson;
 import static berlin.yuna.typemap.logic.TypeConverter.convertObj;
-import static java.util.stream.Collectors.toMap;
+import static berlin.yuna.typemap.model.Type.typeOf;
 
-public class Pair<K, V> implements Map.Entry<K, V> {
+public class Pair<K, V> implements Map.Entry<K, V>, TypeInfo<Pair<K, V>> {
 
     private K key;
     private V value;
@@ -46,6 +45,72 @@ public class Pair<K, V> implements Map.Entry<K, V> {
         return convertObj(value, type);
     }
 
+    public Pair<K, V> to(final Class<K> keyType, final Class<V> valueType) {
+        return new Pair<>(convertObj(key, keyType), convertObj(value, valueType));
+    }
+
+    /**
+     * Wraps the key in a {@link Type} to access conversion helpers such as {@code asInt()}.
+     */
+    public Type<K> keyType() {
+        return typeOf(key);
+    }
+
+    /**
+     * Wraps the value in a {@link Type} to access conversion helpers such as {@code asBoolean()}.
+     */
+    public Type<V> valueType() {
+        return typeOf(value);
+    }
+
+    /**
+     * Alias for {@link #valueType()} to highlight {@link TypeInfo}-style access to the value.
+     */
+    public Type<V> valueInfo() {
+        return valueType();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Pair<K, V> addR(final Object key, final Object value) {
+        if (key != null) {
+            this.key = (K) key;
+        } else {
+            this.value = (V) value;
+        }
+        return this;
+    }
+
+    @Override
+    public Type<TypeMapI<?>> typeMapOpt() {
+        return value instanceof TypeMapI ? typeOf((TypeMapI<?>) value) : typeOf(null);
+    }
+
+    @Override
+    public Type<TypeListI<?>> typeListOpt() {
+        return value instanceof TypeListI ? typeOf((TypeListI<?>) value) : typeOf(null);
+    }
+
+    @Override
+    public Type<?> asOpt(final Object... path) {
+        if (path == null || path.length == 0)
+            return typeOf(value);
+        final Object selector = path[0];
+        if ("key".equals(selector) || (selector instanceof final Number num && num.intValue() == 0))
+            return typeOf(key);
+        if ("value".equals(selector) || (selector instanceof final Number num && num.intValue() == 1))
+            return typeOf(value);
+        return typeOf(null);
+    }
+
+    public <T> T keyAs(final Class<T> type) {
+        return keyType().get(type);
+    }
+
+    public <T> T valueAs(final Class<T> type) {
+        return valueType().get(type);
+    }
+
     @Override
     public K getKey() {
         return key;
@@ -78,7 +143,8 @@ public class Pair<K, V> implements Map.Entry<K, V> {
 
     @Override
     public String toString() {
-        return toJson(Stream.of(new AbstractMap.SimpleEntry<>(key, value)).collect(toMap(Map.Entry::getKey, Map.Entry::getValue)));
+        final Map<Object, Object> map = new LinkedHashMap<>(1);
+        map.put(key, value);
+        return JsonEncoder.toJson(map);
     }
 }
-

--- a/src/main/java/berlin/yuna/typemap/model/Type.java
+++ b/src/main/java/berlin/yuna/typemap/model/Type.java
@@ -10,8 +10,6 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import static berlin.yuna.typemap.model.TypeMap.treeGet;
-
 public class Type<T> implements Iterable<T>, TypeInfo<Type<T>> {
 
     private T value;
@@ -48,7 +46,7 @@ public class Type<T> implements Iterable<T>, TypeInfo<Type<T>> {
      * @return the current instance {@link Type}
      */
     @Override
-    @Deprecated
+    @Deprecated(forRemoval = true)
     @SuppressWarnings("unchecked")
     public Type<T> addR(final Object key, final Object value) {
         this.value = (T) (key != null ? key : value);
@@ -229,8 +227,7 @@ public class Type<T> implements Iterable<T>, TypeInfo<Type<T>> {
 
     @Override
     public boolean equals(final Object o) {
-        if (!(o instanceof Type)) return false;
-        final Type<?> type = (Type<?>) o;
+        if (!(o instanceof final Type<?> type)) return false;
         return Objects.equals(value, type.value);
     }
 

--- a/src/main/java/berlin/yuna/typemap/model/TypeInfo.java
+++ b/src/main/java/berlin/yuna/typemap/model/TypeInfo.java
@@ -1289,7 +1289,7 @@ public interface TypeInfo<C extends TypeInfo<C>> {
      * @return an array of the specified component type.
      */
     default <E> E[] asArray(final IntFunction<E[]> generator, final Class<E> componentType, final Object... path) {
-        return asList(ArrayList::new, componentType, path).stream().toArray(generator);
+        return asList(ArrayList::new, componentType, path).toArray(generator);
     }
 
     /**
@@ -1393,7 +1393,7 @@ public interface TypeInfo<C extends TypeInfo<C>> {
             return putPath(pathAndValue);
 
         final Object key = pathAndValue[pathAndValue.length - 2];
-        final int index = !(key instanceof Number) ? ((List<?>) list).indexOf(key) : ((Number) key).intValue();
+        final int index = !(key instanceof final Number num) ? ((List<?>) list).indexOf(key) : num.intValue();
         if (index > -1 && index < ((List<?>) list).size()) {
             ((List) list).set(index, pathAndValue[pathAndValue.length - 1]);
             return true;
@@ -1415,8 +1415,8 @@ public interface TypeInfo<C extends TypeInfo<C>> {
             return false;
         final boolean isEntry = pathAndValue[pathAndValue.length - 1] instanceof Map.Entry;
         final Object obj = treeGet(this, Arrays.copyOf(pathAndValue, pathAndValue.length - (isEntry ? 1 : 2)));
-        if (obj instanceof Map) {
-            ((Map) obj).put(
+        if (obj instanceof final Map map) {
+            map.put(
                 isEntry ? ((Map.Entry<?, ?>) pathAndValue[pathAndValue.length - 1]).getKey() : pathAndValue[pathAndValue.length - 2],
                 isEntry ? ((Map.Entry<?, ?>) pathAndValue[pathAndValue.length - 1]).getValue() : pathAndValue[pathAndValue.length - 1]
             );

--- a/src/main/java/berlin/yuna/typemap/model/TypeList.java
+++ b/src/main/java/berlin/yuna/typemap/model/TypeList.java
@@ -3,8 +3,11 @@ package berlin.yuna.typemap.model;
 
 import berlin.yuna.typemap.logic.*;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -34,11 +37,11 @@ public class TypeList extends ArrayList<Object> implements TypeListI<TypeList> {
     /**
      * Constructs a new {@link TypeList} of the specified json.
      *
-     * @deprecated use {@link #fromJson(String)} or {@link #fromXml(String)} for clarity
+     * @deprecated use {@link #listOf(String)} for JSON/XML input
      */
     @Deprecated(forRemoval = true)
     public TypeList(final String jsonOrXml) {
-        this(jsonOrXml != null && jsonOrXml.startsWith("<") ? XmlDecoder.xmlTypeOf(jsonOrXml) : JsonDecoder.jsonListOf(jsonOrXml));
+        this(JsonDecoder.listOf(jsonOrXml));
     }
 
     /**
@@ -51,17 +54,129 @@ public class TypeList extends ArrayList<Object> implements TypeListI<TypeList> {
     }
 
     /**
-     * Parses JSON or XML string into a {@link TypeList}.
+     * Parses JSON or XML into a {@link TypeList}.
+     * JSON arrays and XML return the parsed list; objects and primitive values are wrapped into a single-item list.
+     * Returns an empty list when input is null, blank, or cannot be parsed.
      */
+    public static TypeList listOf(final String jsonOrXml) {
+        return JsonDecoder.listOf(jsonOrXml);
+    }
+
+    /**
+     * Parses JSON or XML into a {@link TypeList} from a {@link CharSequence}.
+     * JSON arrays and XML return the parsed list; objects and primitive values are wrapped into a single-item list.
+     * Returns an empty list when input is null, blank, or cannot be parsed.
+     */
+    public static TypeList listOf(final CharSequence jsonOrXml) {
+        return JsonDecoder.listOf(jsonOrXml);
+    }
+
+    /**
+     * Parses JSON or XML into a {@link TypeList} from an {@link InputStream}.
+     * JSON arrays and XML return the parsed list; objects and primitive values are wrapped into a single-item list.
+     * Returns an empty list when input is null or cannot be parsed.
+     */
+    public static TypeList listOf(final InputStream jsonOrXml) {
+        return JsonDecoder.listOf(jsonOrXml);
+    }
+
+    /**
+     * Parses JSON or XML into a {@link TypeList} from an {@link InputStream}.
+     * JSON arrays and XML return the parsed list; objects and primitive values are wrapped into a single-item list.
+     * Uses the provided charset for JSON content. Returns an empty list when input is null or cannot be parsed.
+     */
+    public static TypeList listOf(final InputStream jsonOrXml, final Charset charset) {
+        return JsonDecoder.listOf(jsonOrXml, charset);
+    }
+
+    /**
+     * Parses JSON or XML into a {@link TypeList} from a {@link Path}.
+     * JSON arrays and XML return the parsed list; objects and primitive values are wrapped into a single-item list.
+     * Returns an empty list when input is null or cannot be parsed.
+     */
+    public static TypeList listOf(final Path jsonOrXml) {
+        return JsonDecoder.listOf(jsonOrXml);
+    }
+
+    /**
+     * Parses JSON or XML into a {@link TypeList} from a {@link Path}.
+     * JSON arrays and XML return the parsed list; objects and primitive values are wrapped into a single-item list.
+     * Uses the provided charset for JSON content. Returns an empty list when input is null or cannot be parsed.
+     */
+    public static TypeList listOf(final Path jsonOrXml, final Charset charset) {
+        return JsonDecoder.listOf(jsonOrXml, charset);
+    }
+
+    /**
+     * Parses JSON or XML into a {@link TypeList} from a {@link File}.
+     * JSON arrays and XML return the parsed list; objects and primitive values are wrapped into a single-item list.
+     * Returns an empty list when input is null or cannot be parsed.
+     */
+    public static TypeList listOf(final File jsonOrXml) {
+        return JsonDecoder.listOf(jsonOrXml);
+    }
+
+    /**
+     * Parses JSON or XML into a {@link TypeList} from a {@link File}.
+     * JSON arrays and XML return the parsed list; objects and primitive values are wrapped into a single-item list.
+     * Uses the provided charset for JSON content. Returns an empty list when input is null or cannot be parsed.
+     */
+    public static TypeList listOf(final File jsonOrXml, final Charset charset) {
+        return JsonDecoder.listOf(jsonOrXml, charset);
+    }
+
+    /**
+     * Parses JSON or XML into a {@link TypeList} from a {@link URI}.
+     * JSON arrays and XML return the parsed list; objects and primitive values are wrapped into a single-item list.
+     * Returns an empty list when input is null or cannot be parsed.
+     */
+    public static TypeList listOf(final URI jsonOrXml) {
+        return JsonDecoder.listOf(jsonOrXml);
+    }
+
+    /**
+     * Parses JSON or XML into a {@link TypeList} from a {@link URI}.
+     * JSON arrays and XML return the parsed list; objects and primitive values are wrapped into a single-item list.
+     * Uses the provided charset for JSON content. Returns an empty list when input is null or cannot be parsed.
+     */
+    public static TypeList listOf(final URI jsonOrXml, final Charset charset) {
+        return JsonDecoder.listOf(jsonOrXml, charset);
+    }
+
+    /**
+     * Parses JSON or XML into a {@link TypeList} from a {@link URL}.
+     * JSON arrays and XML return the parsed list; objects and primitive values are wrapped into a single-item list.
+     * Returns an empty list when input is null or cannot be parsed.
+     */
+    public static TypeList listOf(final URL jsonOrXml) {
+        return JsonDecoder.listOf(jsonOrXml);
+    }
+
+    /**
+     * Parses JSON or XML into a {@link TypeList} from a {@link URL}.
+     * JSON arrays and XML return the parsed list; objects and primitive values are wrapped into a single-item list.
+     * Uses the provided charset for JSON content. Returns an empty list when input is null or cannot be parsed.
+     */
+    public static TypeList listOf(final URL jsonOrXml, final Charset charset) {
+        return JsonDecoder.listOf(jsonOrXml, charset);
+    }
+
+    /**
+     * Parses JSON or XML string into a {@link TypeList}.
+     *
+     * @deprecated use {@link #listOf(String)} to accept JSON or XML
+     */
+    @Deprecated(forRemoval = true)
     public static TypeList fromJson(final String jsonOrXml) {
-        return (jsonOrXml == null || jsonOrXml.isBlank())
-            ? new TypeList()
-            : new TypeList(jsonOrXml.startsWith("<") ? XmlDecoder.xmlTypeOf(jsonOrXml) : JsonDecoder.jsonListOf(jsonOrXml));
+        return JsonDecoder.listOf(jsonOrXml);
     }
 
     /**
      * Parses JSON or XML CharSequence into a {@link TypeList}.
+     *
+     * @deprecated use {@link #listOf(CharSequence)} to accept JSON or XML
      */
+    @Deprecated(forRemoval = true)
     public static TypeList fromJson(final CharSequence jsonOrXml) {
         return jsonOrXml == null
             ? new TypeList()
@@ -70,36 +185,51 @@ public class TypeList extends ArrayList<Object> implements TypeListI<TypeList> {
 
     /**
      * Parses JSON or XML stream into a {@link TypeList}.
+     *
+     * @deprecated use {@link #listOf(InputStream)} to accept JSON or XML
      */
+    @Deprecated(forRemoval = true)
     public static TypeList fromJson(final InputStream jsonOrXml) {
         return fromJson(readStream(jsonOrXml));
     }
 
     /**
      * Parses JSON or XML stream into a {@link TypeList}.
+     *
+     * @deprecated use {@link #listOf(InputStream)} or {@link #listOf(InputStream, Charset)}
      */
+    @Deprecated(forRemoval = true)
     public static TypeList from(final InputStream input) {
         return from(input, UTF_8);
     }
 
     /**
      * Parses JSON or XML stream into a {@link TypeList} with the given charset for JSON content.
+     *
+     * @deprecated use {@link #listOf(InputStream, Charset)}
      */
+    @Deprecated(forRemoval = true)
     public static TypeList from(final InputStream input, final Charset charset) {
-        return input == null ? new TypeList() : JsonDecoder.jsonListOf(input, charset);
+        return input == null ? new TypeList() : JsonDecoder.listOf(input, charset);
     }
 
 
     /**
      * Parses XML string into a {@link TypeList}.
+     *
+     * @deprecated use {@link #listOf(String)} to accept JSON or XML
      */
+    @Deprecated(forRemoval = true)
     public static TypeList fromXml(final String xml) {
         return new TypeList(XmlDecoder.xmlTypeOf(xml));
     }
 
     /**
      * Parses XML CharSequence into a {@link TypeList}.
+     *
+     * @deprecated use {@link #listOf(CharSequence)} to accept JSON or XML
      */
+    @Deprecated(forRemoval = true)
     public static TypeList fromXml(final CharSequence xml) {
         return xml == null
             ? new TypeList()
@@ -108,14 +238,20 @@ public class TypeList extends ArrayList<Object> implements TypeListI<TypeList> {
 
     /**
      * Parses XML file into a {@link TypeList}.
+     *
+     * @deprecated use {@link #listOf(Path)} to accept JSON or XML
      */
+    @Deprecated(forRemoval = true)
     public static TypeList fromXml(final Path xml) {
         return fromXml(readPath(xml));
     }
 
     /**
      * Parses XML stream into a {@link TypeList}.
+     *
+     * @deprecated use {@link #listOf(InputStream)} to accept JSON or XML
      */
+    @Deprecated(forRemoval = true)
     public static TypeList fromXml(final InputStream xml) {
         return fromXml(readStream(xml));
     }

--- a/src/main/java/berlin/yuna/typemap/model/TypeList.java
+++ b/src/main/java/berlin/yuna/typemap/model/TypeList.java
@@ -68,13 +68,6 @@ public class TypeList extends ArrayList<Object> implements TypeListI<TypeList> {
     }
 
     /**
-     * Parses JSON or XML file into a {@link TypeList}.
-     */
-    public static TypeList fromJson(final Path jsonOrXml) {
-        return fromJson(readPath(jsonOrXml));
-    }
-
-    /**
      * Parses JSON or XML stream into a {@link TypeList}.
      */
     public static TypeList fromJson(final InputStream jsonOrXml) {
@@ -134,7 +127,11 @@ public class TypeList extends ArrayList<Object> implements TypeListI<TypeList> {
     }
 
     public static TypeList fromArgs(final Path args) {
-        return fromArgs(readPath(args));
+        try (InputStream in = Files.newInputStream(args)) {
+            return fromArgs(in);
+        } catch (final IOException ignored) {
+            return new TypeList();
+        }
     }
 
     public static TypeList fromArgs(final InputStream args) {

--- a/src/main/java/berlin/yuna/typemap/model/TypeList.java
+++ b/src/main/java/berlin/yuna/typemap/model/TypeList.java
@@ -5,13 +5,14 @@ import berlin.yuna.typemap.logic.*;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Optional.ofNullable;
 
 /**
@@ -73,6 +74,7 @@ public class TypeList extends ArrayList<Object> implements TypeListI<TypeList> {
     public static TypeList fromJson(final InputStream jsonOrXml) {
         return fromJson(readStream(jsonOrXml));
     }
+
 
     /**
      * Parses XML string into a {@link TypeList}.
@@ -195,7 +197,7 @@ public class TypeList extends ArrayList<Object> implements TypeListI<TypeList> {
             return "";
         }
         try {
-            return Files.readString(path, StandardCharsets.UTF_8);
+            return Files.readString(path, UTF_8);
         } catch (final IOException ignored) {
             return "";
         }
@@ -206,7 +208,7 @@ public class TypeList extends ArrayList<Object> implements TypeListI<TypeList> {
             return "";
         }
         try {
-            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+            return new String(stream.readAllBytes(), UTF_8);
         } catch (final IOException ignored) {
             return "";
         }

--- a/src/main/java/berlin/yuna/typemap/model/TypeList.java
+++ b/src/main/java/berlin/yuna/typemap/model/TypeList.java
@@ -75,6 +75,20 @@ public class TypeList extends ArrayList<Object> implements TypeListI<TypeList> {
         return fromJson(readStream(jsonOrXml));
     }
 
+    /**
+     * Parses JSON or XML stream into a {@link TypeList}.
+     */
+    public static TypeList from(final InputStream input) {
+        return from(input, UTF_8);
+    }
+
+    /**
+     * Parses JSON or XML stream into a {@link TypeList} with the given charset for JSON content.
+     */
+    public static TypeList from(final InputStream input, final Charset charset) {
+        return input == null ? new TypeList() : JsonDecoder.jsonListOf(input, charset);
+    }
+
 
     /**
      * Parses XML string into a {@link TypeList}.
@@ -207,8 +221,8 @@ public class TypeList extends ArrayList<Object> implements TypeListI<TypeList> {
         if (stream == null) {
             return "";
         }
-        try {
-            return new String(stream.readAllBytes(), UTF_8);
+        try (InputStream in = stream) {
+            return new String(in.readAllBytes(), UTF_8);
         } catch (final IOException ignored) {
             return "";
         }

--- a/src/main/java/berlin/yuna/typemap/model/TypeListI.java
+++ b/src/main/java/berlin/yuna/typemap/model/TypeListI.java
@@ -10,12 +10,31 @@ import static berlin.yuna.typemap.model.Type.typeOf;
 
 public interface TypeListI<C extends TypeListI<C>> extends List<Object>, TypeInfo<C> {
 
+    /**
+     * Adds a value at the given index (or appends when index is negative) and returns this instance for chaining.
+     *
+     * @param index index to insert at, or negative to append
+     * @param value value to add
+     * @return this list instance
+     */
     C addR(final int index, final Object value);
 
+    /**
+     * Appends a value and returns this instance for chaining.
+     *
+     * @param value value to add
+     * @return this list instance
+     */
     default C addR(final Object value) {
         return addR(-1, value);
     }
 
+    /**
+     * Adds all values from the given collection and returns this instance for chaining.
+     *
+     * @param collection collection of values to add
+     * @return this list instance
+     */
     default C addAllR(final Collection<?> collection) {
         addAll(collection);
         return (C) this;
@@ -31,14 +50,28 @@ public interface TypeListI<C extends TypeListI<C>> extends List<Object>, TypeInf
         return typeOf(this);
     }
 
+    /**
+     * Streams list content as index/value pairs.
+     */
     default Stream<Pair<Integer, Object>> streamPairs() {
         return streamPairs(null, (Object[]) null);
     }
 
+    /**
+     * Streams list content as index/value pairs, converting values to the given type.
+     *
+     * @param valueType optional target type for values
+     */
     default <V> Stream<Pair<Integer, V>> streamPairs(final Class<V> valueType) {
         return streamPairs(valueType, (Object[]) null);
     }
 
+    /**
+     * Streams list content as index/value pairs from a nested map/list path, converting values to the given type.
+     *
+     * @param valueType optional target type for values
+     * @param path      path to a nested map/list
+     */
     default <V> Stream<Pair<Integer, V>> streamPairs(final Class<V> valueType, final Object... path) {
         return TypeInfo.super.streamAny(valueType, path)
             .map(p -> new Pair<>(convertObj(p.key(), Integer.class), p.value()));

--- a/src/main/java/berlin/yuna/typemap/model/TypeListI.java
+++ b/src/main/java/berlin/yuna/typemap/model/TypeListI.java
@@ -2,60 +2,45 @@ package berlin.yuna.typemap.model;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
+import java.util.stream.Stream;
 
+import static berlin.yuna.typemap.logic.TypeConverter.convertObj;
 import static berlin.yuna.typemap.model.Type.empty;
 import static berlin.yuna.typemap.model.Type.typeOf;
 
 public interface TypeListI<C extends TypeListI<C>> extends List<Object>, TypeInfo<C> {
 
-    /**
-     * Adds the specified value
-     *
-     * @param index the index whose associated value is to be returned.
-     * @param value the value to be added
-     * @return the updated {@link TypeListI} instance for chaining.
-     */
     C addR(final int index, final Object value);
 
-    /**
-     * Adds the specified value
-     *
-     * @param value the value to be added
-     * @return the updated TypeList instance for chaining.
-     */
     default C addR(final Object value) {
         return addR(-1, value);
     }
 
-    /**
-     * Adds all entries to this specified List
-     *
-     * @param collection which provides all entries to add
-     * @return the updated {@link TypeListI} instance for chaining.
-     */
     default C addAllR(final Collection<?> collection) {
         addAll(collection);
         return (C) this;
     }
 
-    /**
-     * Fluent typecheck if the current {@link TypeInfo} is a {@link TypeMapI}
-     *
-     * @return {@link Optional#empty()} if current object is not a {@link TypeMapI}, else returns self.
-     */
     @SuppressWarnings("java:S1452")
     default Type<TypeMapI<?>> typeMapOpt() {
         return empty();
     }
 
-    /**
-     * Fluent typecheck if the current {@link TypeInfo} is a {@link TypeListI}
-     *
-     * @return {@link Optional#empty()} if current object is not a {@link TypeListI}, else returns self.
-     */
     @SuppressWarnings("java:S1452")
     default Type<TypeListI<?>> typeListOpt() {
         return typeOf(this);
+    }
+
+    default Stream<Pair<Integer, Object>> streamPairs() {
+        return streamPairs(null, (Object[]) null);
+    }
+
+    default <V> Stream<Pair<Integer, V>> streamPairs(final Class<V> valueType) {
+        return streamPairs(valueType, (Object[]) null);
+    }
+
+    default <V> Stream<Pair<Integer, V>> streamPairs(final Class<V> valueType, final Object... path) {
+        return TypeInfo.super.streamAny(valueType, path)
+            .map(p -> new Pair<>(convertObj(p.key(), Integer.class), p.value()));
     }
 }

--- a/src/main/java/berlin/yuna/typemap/model/TypeMap.java
+++ b/src/main/java/berlin/yuna/typemap/model/TypeMap.java
@@ -6,9 +6,11 @@ import berlin.yuna.typemap.logic.JsonDecoder;
 import berlin.yuna.typemap.logic.TypeConverter;
 import berlin.yuna.typemap.logic.XmlDecoder;
 
-import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -42,11 +44,11 @@ public class TypeMap extends HashMap<Object, Object> implements TypeMapI<TypeMap
     /**
      * Constructs a new {@link TypeMap} of the specified json.
      *
-     * @deprecated use {@link #fromJson(String)} or {@link #fromXml(String)} for clarity
+     * @deprecated use {@link #mapOf(String)} for JSON/XML input
      */
     @Deprecated(forRemoval = true)
     public TypeMap(final String json) {
-        this(JsonDecoder.jsonMapOf(json));
+        this(JsonDecoder.mapOf(json));
     }
 
     /**
@@ -69,20 +71,131 @@ public class TypeMap extends HashMap<Object, Object> implements TypeMapI<TypeMap
     }
 
     /**
-     * Parses JSON into a {@link TypeMapI} (returns {@link LinkedTypeMap} when possible).
-     *
-     * @param json raw json content
-     * @return populated map or empty map when input is blank
+     * Parses JSON or XML into a {@link LinkedTypeMap}.
+     * JSON objects become map entries; arrays, XML, and primitive values are wrapped under the "" key.
+     * Returns an empty map when input is null, blank, or cannot be parsed.
      */
+    public static LinkedTypeMap mapOf(final String jsonOrXml) {
+        return JsonDecoder.mapOf(jsonOrXml);
+    }
+
+    /**
+     * Parses JSON or XML into a {@link LinkedTypeMap} from a {@link CharSequence}.
+     * JSON objects become map entries; arrays, XML, and primitive values are wrapped under the "" key.
+     * Returns an empty map when input is null, blank, or cannot be parsed.
+     */
+    public static LinkedTypeMap mapOf(final CharSequence jsonOrXml) {
+        return JsonDecoder.mapOf(jsonOrXml);
+    }
+
+    /**
+     * Parses JSON or XML into a {@link LinkedTypeMap} from an {@link InputStream}.
+     * JSON objects become map entries; arrays, XML, and primitive values are wrapped under the "" key.
+     * Returns an empty map when input is null or cannot be parsed.
+     */
+    public static LinkedTypeMap mapOf(final InputStream jsonOrXml) {
+        return JsonDecoder.mapOf(jsonOrXml);
+    }
+
+    /**
+     * Parses JSON or XML into a {@link LinkedTypeMap} from an {@link InputStream}.
+     * JSON objects become map entries; arrays, XML, and primitive values are wrapped under the "" key.
+     * Uses the provided charset for JSON content. Returns an empty map when input is null or cannot be parsed.
+     */
+    public static LinkedTypeMap mapOf(final InputStream jsonOrXml, final Charset charset) {
+        return JsonDecoder.mapOf(jsonOrXml, charset);
+    }
+
+    /**
+     * Parses JSON or XML into a {@link LinkedTypeMap} from a {@link Path}.
+     * JSON objects become map entries; arrays, XML, and primitive values are wrapped under the "" key.
+     * Returns an empty map when input is null or cannot be parsed.
+     */
+    public static LinkedTypeMap mapOf(final Path jsonOrXml) {
+        return JsonDecoder.mapOf(jsonOrXml);
+    }
+
+    /**
+     * Parses JSON or XML into a {@link LinkedTypeMap} from a {@link Path}.
+     * JSON objects become map entries; arrays, XML, and primitive values are wrapped under the "" key.
+     * Uses the provided charset for JSON content. Returns an empty map when input is null or cannot be parsed.
+     */
+    public static LinkedTypeMap mapOf(final Path jsonOrXml, final Charset charset) {
+        return JsonDecoder.mapOf(jsonOrXml, charset);
+    }
+
+    /**
+     * Parses JSON or XML into a {@link LinkedTypeMap} from a {@link File}.
+     * JSON objects become map entries; arrays, XML, and primitive values are wrapped under the "" key.
+     * Returns an empty map when input is null or cannot be parsed.
+     */
+    public static LinkedTypeMap mapOf(final File jsonOrXml) {
+        return JsonDecoder.mapOf(jsonOrXml);
+    }
+
+    /**
+     * Parses JSON or XML into a {@link LinkedTypeMap} from a {@link File}.
+     * JSON objects become map entries; arrays, XML, and primitive values are wrapped under the "" key.
+     * Uses the provided charset for JSON content. Returns an empty map when input is null or cannot be parsed.
+     */
+    public static LinkedTypeMap mapOf(final File jsonOrXml, final Charset charset) {
+        return JsonDecoder.mapOf(jsonOrXml, charset);
+    }
+
+    /**
+     * Parses JSON or XML into a {@link LinkedTypeMap} from a {@link URI}.
+     * JSON objects become map entries; arrays, XML, and primitive values are wrapped under the "" key.
+     * Returns an empty map when input is null or cannot be parsed.
+     */
+    public static LinkedTypeMap mapOf(final URI jsonOrXml) {
+        return JsonDecoder.mapOf(jsonOrXml);
+    }
+
+    /**
+     * Parses JSON or XML into a {@link LinkedTypeMap} from a {@link URI}.
+     * JSON objects become map entries; arrays, XML, and primitive values are wrapped under the "" key.
+     * Uses the provided charset for JSON content. Returns an empty map when input is null or cannot be parsed.
+     */
+    public static LinkedTypeMap mapOf(final URI jsonOrXml, final Charset charset) {
+        return JsonDecoder.mapOf(jsonOrXml, charset);
+    }
+
+    /**
+     * Parses JSON or XML into a {@link LinkedTypeMap} from a {@link URL}.
+     * JSON objects become map entries; arrays, XML, and primitive values are wrapped under the "" key.
+     * Returns an empty map when input is null or cannot be parsed.
+     */
+    public static LinkedTypeMap mapOf(final URL jsonOrXml) {
+        return JsonDecoder.mapOf(jsonOrXml);
+    }
+
+    /**
+     * Parses JSON or XML into a {@link LinkedTypeMap} from a {@link URL}.
+     * JSON objects become map entries; arrays, XML, and primitive values are wrapped under the "" key.
+     * Uses the provided charset for JSON content. Returns an empty map when input is null or cannot be parsed.
+     */
+    public static LinkedTypeMap mapOf(final URL jsonOrXml, final Charset charset) {
+        return JsonDecoder.mapOf(jsonOrXml, charset);
+    }
+
+    /**
+     * Parses JSON into a {@link TypeMapI} (explicit JSON path).
+     *
+     * @deprecated use {@link #mapOf(String)} to accept JSON or XML
+     */
+    @Deprecated(forRemoval = true)
     public static LinkedTypeMap fromJson(final String json) {
         return (json == null || json.isBlank())
             ? new LinkedTypeMap()
-            : JsonDecoder.jsonMapOf(json);
+            : JsonDecoder.mapOf(json);
     }
 
     /**
      * Parses JSON CharSequence into a {@link TypeMapI}.
+     *
+     * @deprecated use {@link #mapOf(CharSequence)} to accept JSON or XML
      */
+    @Deprecated(forRemoval = true)
     public static LinkedTypeMap fromJson(final CharSequence json) {
         return json == null
             ? new LinkedTypeMap()
@@ -91,7 +204,10 @@ public class TypeMap extends HashMap<Object, Object> implements TypeMapI<TypeMap
 
     /**
      * Parses JSON file into a {@link TypeMapI}.
+     *
+     * @deprecated use {@link #mapOf(Path)} to accept JSON or XML
      */
+    @Deprecated(forRemoval = true)
     public static LinkedTypeMap fromJson(final Path json) {
         try (final InputStream in = Files.newInputStream(json)) {
             return fromJson(in);
@@ -102,35 +218,50 @@ public class TypeMap extends HashMap<Object, Object> implements TypeMapI<TypeMap
 
     /**
      * Parses JSON stream into a {@link TypeMapI}.
+     *
+     * @deprecated use {@link #mapOf(InputStream)} to accept JSON or XML
      */
+    @Deprecated(forRemoval = true)
     public static LinkedTypeMap fromJson(final InputStream json) {
         return fromJson(readStream(json));
     }
 
     /**
      * Parses JSON or XML stream into a {@link TypeMapI}.
+     *
+     * @deprecated use {@link #mapOf(InputStream)} or {@link #mapOf(InputStream, Charset)}
      */
+    @Deprecated(forRemoval = true)
     public static LinkedTypeMap from(final InputStream input) {
         return from(input, UTF_8);
     }
 
     /**
      * Parses JSON or XML stream into a {@link TypeMapI} with the given charset for JSON content.
+     *
+     * @deprecated use {@link #mapOf(InputStream, Charset)}
      */
+    @Deprecated(forRemoval = true)
     public static LinkedTypeMap from(final InputStream input, final Charset charset) {
-        return input == null ? new LinkedTypeMap() : JsonDecoder.jsonMapOf(input, charset);
+        return input == null ? new LinkedTypeMap() : JsonDecoder.mapOf(input, charset);
     }
 
     /**
      * Parses XML into a {@link LinkedTypeMap} preserving element order.
+     *
+     * @deprecated use {@link #mapOf(String)} to accept JSON or XML
      */
+    @Deprecated(forRemoval = true)
     public static LinkedTypeMap fromXml(final String xml) {
         return fromXml(XmlDecoder.xmlTypeOf(xml));
     }
 
     /**
      * Parses XML CharSequence into a {@link TypeMapI}.
+     *
+     * @deprecated use {@link #mapOf(CharSequence)} to accept JSON or XML
      */
+    @Deprecated(forRemoval = true)
     public static LinkedTypeMap fromXml(final CharSequence xml) {
         return xml == null
             ? new LinkedTypeMap()
@@ -139,7 +270,10 @@ public class TypeMap extends HashMap<Object, Object> implements TypeMapI<TypeMap
 
     /**
      * Parses XML file into a {@link TypeMapI}.
+     *
+     * @deprecated use {@link #mapOf(Path)} to accept JSON or XML
      */
+    @Deprecated(forRemoval = true)
     public static LinkedTypeMap fromXml(final Path xml) {
         try (final InputStream in = Files.newInputStream(xml)) {
             return fromXml(in);
@@ -150,7 +284,10 @@ public class TypeMap extends HashMap<Object, Object> implements TypeMapI<TypeMap
 
     /**
      * Parses XML stream into a {@link TypeMapI}.
+     *
+     * @deprecated use {@link #mapOf(InputStream)} to accept JSON or XML
      */
+    @Deprecated(forRemoval = true)
     public static LinkedTypeMap fromXml(final InputStream xml) {
         return fromXml(readStream(xml));
     }

--- a/src/main/java/berlin/yuna/typemap/model/TypeMap.java
+++ b/src/main/java/berlin/yuna/typemap/model/TypeMap.java
@@ -6,9 +6,10 @@ import berlin.yuna.typemap.logic.JsonDecoder;
 import berlin.yuna.typemap.logic.TypeConverter;
 import berlin.yuna.typemap.logic.XmlDecoder;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
@@ -18,6 +19,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static berlin.yuna.typemap.logic.TypeConverter.iterateOverArray;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyMap;
 import static java.util.Optional.ofNullable;
 
@@ -198,7 +200,7 @@ public class TypeMap extends HashMap<Object, Object> implements TypeMapI<TypeMap
             return "";
         }
         try {
-            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+            return new String(stream.readAllBytes(), UTF_8);
         } catch (final IOException ignored) {
             return "";
         }

--- a/src/main/java/berlin/yuna/typemap/model/TypeMap.java
+++ b/src/main/java/berlin/yuna/typemap/model/TypeMap.java
@@ -108,6 +108,20 @@ public class TypeMap extends HashMap<Object, Object> implements TypeMapI<TypeMap
     }
 
     /**
+     * Parses JSON or XML stream into a {@link TypeMapI}.
+     */
+    public static LinkedTypeMap from(final InputStream input) {
+        return from(input, UTF_8);
+    }
+
+    /**
+     * Parses JSON or XML stream into a {@link TypeMapI} with the given charset for JSON content.
+     */
+    public static LinkedTypeMap from(final InputStream input, final Charset charset) {
+        return input == null ? new LinkedTypeMap() : JsonDecoder.jsonMapOf(input, charset);
+    }
+
+    /**
      * Parses XML into a {@link LinkedTypeMap} preserving element order.
      */
     public static LinkedTypeMap fromXml(final String xml) {
@@ -199,8 +213,8 @@ public class TypeMap extends HashMap<Object, Object> implements TypeMapI<TypeMap
         if (stream == null) {
             return "";
         }
-        try {
-            return new String(stream.readAllBytes(), UTF_8);
+        try (InputStream in = stream) {
+            return new String(in.readAllBytes(), UTF_8);
         } catch (final IOException ignored) {
             return "";
         }

--- a/src/main/java/berlin/yuna/typemap/model/TypeMapI.java
+++ b/src/main/java/berlin/yuna/typemap/model/TypeMapI.java
@@ -9,6 +9,13 @@ import static berlin.yuna.typemap.model.Type.empty;
 import static berlin.yuna.typemap.model.Type.typeOf;
 public interface TypeMapI<C extends TypeMapI<C>> extends Map<Object, Object>, TypeInfo<C> {
 
+    /**
+     * Adds a mapping and returns this instance for chaining.
+     *
+     * @param key   map key
+     * @param value map value
+     * @return this map instance
+     */
     @SuppressWarnings("unchecked")
     default C putR(final Object key, final Object value) {
         put(key, value);
@@ -27,18 +34,37 @@ public interface TypeMapI<C extends TypeMapI<C>> extends Map<Object, Object>, Ty
         return XmlEncoder.toXmlMap(this);
     }
 
+    /**
+     * Streams map content as key/value pairs.
+     */
     default Stream<Pair<String, Object>> streamPairs() {
         return streamPairs(null, (Object[]) null);
     }
 
+    /**
+     * Streams map content as key/value pairs, converting values to the given type.
+     *
+     * @param valueType optional target type for values
+     */
     default <V> Stream<Pair<String, V>> streamPairs(final Class<V> valueType) {
         return streamPairs(valueType, (Object[]) null);
     }
 
+    /**
+     * Streams map content as key/value pairs from a nested map/list path, converting values to the given type.
+     *
+     * @param valueType optional target type for values
+     * @param path      path to a nested map/list
+     */
     default <V> Stream<Pair<String, V>> streamPairs(final Class<V> valueType, final Object... path) {
         return TypeInfo.super.streamAny(valueType, path).map(p -> new Pair<>(String.valueOf(p.key()), p.value()));
     }
 
+    /**
+     * Streams map content as key/value pairs from a nested map/list path.
+     *
+     * @param path path to a nested map/list
+     */
     default Stream<Pair<String, Object>> streamPairs(final Object... path) {
         return streamPairs(null, path);
     }

--- a/src/main/java/berlin/yuna/typemap/model/TypeMapI.java
+++ b/src/main/java/berlin/yuna/typemap/model/TypeMapI.java
@@ -1,5 +1,7 @@
 package berlin.yuna.typemap.model;
 
+import berlin.yuna.typemap.logic.XmlEncoder;
+
 import java.util.Map;
 import java.util.Optional;
 
@@ -37,5 +39,9 @@ public interface TypeMapI<C extends TypeMapI<C>> extends Map<Object, Object>, Ty
      */
     default Type<TypeListI<?>> typeListOpt() {
         return empty();
+    }
+
+    default String toXML() {
+        return XmlEncoder.toXmlMap(this);
     }
 }

--- a/src/main/java/berlin/yuna/typemap/model/TypeMapI.java
+++ b/src/main/java/berlin/yuna/typemap/model/TypeMapI.java
@@ -3,45 +3,43 @@ package berlin.yuna.typemap.model;
 import berlin.yuna.typemap.logic.XmlEncoder;
 
 import java.util.Map;
-import java.util.Optional;
+import java.util.stream.Stream;
 
 import static berlin.yuna.typemap.model.Type.empty;
 import static berlin.yuna.typemap.model.Type.typeOf;
-
 public interface TypeMapI<C extends TypeMapI<C>> extends Map<Object, Object>, TypeInfo<C> {
 
-    /**
-     * Associates the specified value with the specified key in this map.
-     *
-     * @param key   the key with which the specified value is to be associated.
-     * @param value the value to be associated with the specified key.
-     * @return the updated TypeMap instance for chaining.
-     */
     @SuppressWarnings("unchecked")
     default C putR(final Object key, final Object value) {
         put(key, value);
         return (C) this;
     }
 
-    /**
-     * Fluent typecheck if the current {@link TypeInfo} is a {@link TypeMapI}
-     *
-     * @return {@link Optional#empty()} if current object is not a {@link TypeMapI}, else returns self.
-     */
     default Type<TypeMapI<?>> typeMapOpt() {
         return typeOf(this);
     }
 
-    /**
-     * Fluent typecheck if the current {@link TypeInfo} is a {@link TypeListI}
-     *
-     * @return {@link Optional#empty()} if current object is not a {@link TypeListI}, else returns self.
-     */
     default Type<TypeListI<?>> typeListOpt() {
         return empty();
     }
 
     default String toXML() {
         return XmlEncoder.toXmlMap(this);
+    }
+
+    default Stream<Pair<String, Object>> streamPairs() {
+        return streamPairs(null, (Object[]) null);
+    }
+
+    default <V> Stream<Pair<String, V>> streamPairs(final Class<V> valueType) {
+        return streamPairs(valueType, (Object[]) null);
+    }
+
+    default <V> Stream<Pair<String, V>> streamPairs(final Class<V> valueType, final Object... path) {
+        return TypeInfo.super.streamAny(valueType, path).map(p -> new Pair<>(String.valueOf(p.key()), p.value()));
+    }
+
+    default Stream<Pair<String, Object>> streamPairs(final Object... path) {
+        return streamPairs(null, path);
     }
 }

--- a/src/main/java/berlin/yuna/typemap/model/TypeSet.java
+++ b/src/main/java/berlin/yuna/typemap/model/TypeSet.java
@@ -28,7 +28,7 @@ public class TypeSet extends ArrayList<Object> implements TypeListI<TypeSet> {
      * Constructs a new {@link TypeSet} of the specified json.
      */
     public TypeSet(final String json) {
-        this(JsonDecoder.jsonListOf(json));
+        this(JsonDecoder.listOf(json));
     }
 
     /**

--- a/src/test/java/berlin/yuna/typemap/logic/JsonDecoderTest.java
+++ b/src/test/java/berlin/yuna/typemap/logic/JsonDecoderTest.java
@@ -116,6 +116,27 @@ class JsonDecoderTest {
     }
 
     @Test
+    void shouldHandleInvalidEscapesAsUnchecked() {
+        final String invalid = "{\"msg\":\"bad\\u00\"}";
+        assertThatThrownBy(() -> JsonDecoder.streamJsonObject(invalid).toList())
+            .isInstanceOf(UncheckedIOException.class);
+    }
+
+    @Test
+    void shouldStopArrayStreamOnMalformedSeparator() {
+        final String broken = "[1 2]";
+        assertThatThrownBy(() -> JsonDecoder.streamJsonArray(broken).toList())
+            .isInstanceOf(UncheckedIOException.class);
+    }
+
+    @Test
+    void shouldStopObjectStreamOnMalformedSeparator() {
+        final String broken = "{\"a\":1 \"b\":2}";
+        assertThatThrownBy(() -> JsonDecoder.streamJsonObject(broken).toList())
+            .isInstanceOf(UncheckedIOException.class);
+    }
+
+    @Test
     void shouldReturnEmptyOnNullOrWhitespace() {
         assertThat(JsonDecoder.streamJson((InputStream) null)).isEmpty();
         try (final Stream<Pair<Object, Object>> stream = JsonDecoder.streamJson("   ")) {

--- a/src/test/java/berlin/yuna/typemap/logic/JsonDecoderTest.java
+++ b/src/test/java/berlin/yuna/typemap/logic/JsonDecoderTest.java
@@ -226,9 +226,9 @@ class JsonDecoderTest {
             supplier(() -> JsonDecoder.mapOf(uri, StandardCharsets.UTF_8)),
             supplier(() -> JsonDecoder.mapOf(url)),
             supplier(() -> JsonDecoder.mapOf(url, StandardCharsets.UTF_8)),
-            supplier(() -> JsonDecoder.jsonMapOf(json)),
-            supplier(() -> JsonDecoder.jsonMapOf(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)))),
-            supplier(() -> JsonDecoder.jsonMapOf(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8))
+            supplier(() -> JsonDecoder.mapOf(json)),
+            supplier(() -> JsonDecoder.mapOf(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)))),
+            supplier(() -> JsonDecoder.mapOf(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8))
         );
 
         suppliers.forEach(supplier -> assertThat(supplier.get()).isEqualTo(expected));
@@ -257,9 +257,9 @@ class JsonDecoderTest {
             supplier(() -> JsonDecoder.listOf(uri, StandardCharsets.UTF_8)),
             supplier(() -> JsonDecoder.listOf(url)),
             supplier(() -> JsonDecoder.listOf(url, StandardCharsets.UTF_8)),
-            supplier(() -> JsonDecoder.jsonListOf(json)),
-            supplier(() -> JsonDecoder.jsonListOf(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)))),
-            supplier(() -> JsonDecoder.jsonListOf(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8))
+            supplier(() -> JsonDecoder.listOf(json)),
+            supplier(() -> JsonDecoder.listOf(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)))),
+            supplier(() -> JsonDecoder.listOf(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8))
         );
 
         suppliers.forEach(supplier -> assertThat(supplier.get()).isEqualTo(expected));
@@ -293,7 +293,7 @@ class JsonDecoderTest {
     void shouldDetectJsonAfterLargeWhitespace() {
         final String json = " ".repeat(2048) + "{\"a\":1}";
         final ByteArrayInputStream input = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
-        final LinkedTypeMap map = JsonDecoder.jsonMapOf(input, StandardCharsets.UTF_8);
+        final LinkedTypeMap map = JsonDecoder.mapOf(input, StandardCharsets.UTF_8);
         assertThat(map).containsEntry("a", 1L);
     }
 

--- a/src/test/java/berlin/yuna/typemap/logic/JsonDecoderTest.java
+++ b/src/test/java/berlin/yuna/typemap/logic/JsonDecoderTest.java
@@ -204,6 +204,80 @@ class JsonDecoderTest {
     }
 
     @Test
+    void shouldMapOfOverloads() throws Exception {
+        final String json = "{\"name\":\"neo\",\"tags\":[\"a\"]}";
+        final Path file = Files.createTempFile("mapof-json", ".json");
+        Files.writeString(file, json, StandardCharsets.UTF_8);
+        final File asFile = file.toFile();
+        final URI uri = file.toUri();
+        final URL url = uri.toURL();
+        final LinkedTypeMap expected = JsonDecoder.mapOf(json);
+
+        final List<Supplier<LinkedTypeMap>> suppliers = List.of(
+            supplier(() -> JsonDecoder.mapOf(json)),
+            supplier(() -> JsonDecoder.mapOf(new StringBuilder(json))),
+            supplier(() -> JsonDecoder.mapOf(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)))),
+            supplier(() -> JsonDecoder.mapOf(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8)),
+            supplier(() -> JsonDecoder.mapOf(file)),
+            supplier(() -> JsonDecoder.mapOf(file, StandardCharsets.UTF_8)),
+            supplier(() -> JsonDecoder.mapOf(asFile)),
+            supplier(() -> JsonDecoder.mapOf(asFile, StandardCharsets.UTF_8)),
+            supplier(() -> JsonDecoder.mapOf(uri)),
+            supplier(() -> JsonDecoder.mapOf(uri, StandardCharsets.UTF_8)),
+            supplier(() -> JsonDecoder.mapOf(url)),
+            supplier(() -> JsonDecoder.mapOf(url, StandardCharsets.UTF_8)),
+            supplier(() -> JsonDecoder.jsonMapOf(json)),
+            supplier(() -> JsonDecoder.jsonMapOf(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)))),
+            supplier(() -> JsonDecoder.jsonMapOf(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8))
+        );
+
+        suppliers.forEach(supplier -> assertThat(supplier.get()).isEqualTo(expected));
+    }
+
+    @Test
+    void shouldListOfOverloads() throws Exception {
+        final String json = "[1,true]";
+        final Path file = Files.createTempFile("listof-json", ".json");
+        Files.writeString(file, json, StandardCharsets.UTF_8);
+        final File asFile = file.toFile();
+        final URI uri = file.toUri();
+        final URL url = uri.toURL();
+        final TypeList expected = JsonDecoder.listOf(json);
+
+        final List<Supplier<TypeList>> suppliers = List.of(
+            supplier(() -> JsonDecoder.listOf(json)),
+            supplier(() -> JsonDecoder.listOf(new StringBuilder(json))),
+            supplier(() -> JsonDecoder.listOf(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)))),
+            supplier(() -> JsonDecoder.listOf(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8)),
+            supplier(() -> JsonDecoder.listOf(file)),
+            supplier(() -> JsonDecoder.listOf(file, StandardCharsets.UTF_8)),
+            supplier(() -> JsonDecoder.listOf(asFile)),
+            supplier(() -> JsonDecoder.listOf(asFile, StandardCharsets.UTF_8)),
+            supplier(() -> JsonDecoder.listOf(uri)),
+            supplier(() -> JsonDecoder.listOf(uri, StandardCharsets.UTF_8)),
+            supplier(() -> JsonDecoder.listOf(url)),
+            supplier(() -> JsonDecoder.listOf(url, StandardCharsets.UTF_8)),
+            supplier(() -> JsonDecoder.jsonListOf(json)),
+            supplier(() -> JsonDecoder.jsonListOf(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)))),
+            supplier(() -> JsonDecoder.jsonListOf(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8))
+        );
+
+        suppliers.forEach(supplier -> assertThat(supplier.get()).isEqualTo(expected));
+    }
+
+    @Test
+    void shouldMapAndListOfXml() {
+        final String xml = "<root><item>1</item><item>2</item></root>";
+        final TypeList expectedList = XmlDecoder.xmlTypeOf(xml);
+        final LinkedTypeMap expectedMap = new LinkedTypeMap().putR("", expectedList);
+
+        assertThat(JsonDecoder.listOf(xml)).isEqualTo(expectedList);
+        assertThat(JsonDecoder.listOf(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8)).isEqualTo(expectedList);
+        assertThat(JsonDecoder.mapOf(xml)).isEqualTo(expectedMap);
+        assertThat(JsonDecoder.mapOf(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8)).isEqualTo(expectedMap);
+    }
+
+    @Test
     void shouldStreamArrayAllowNullElements() {
         final String json = "[1,null,2]";
         try (Stream<Pair<Integer, Object>> stream = JsonDecoder.streamJsonArray(json)) {

--- a/src/test/java/berlin/yuna/typemap/logic/JsonDecoderTest.java
+++ b/src/test/java/berlin/yuna/typemap/logic/JsonDecoderTest.java
@@ -1,0 +1,99 @@
+package berlin.yuna.typemap.logic;
+
+import berlin.yuna.typemap.model.LinkedTypeMap;
+import berlin.yuna.typemap.model.Pair;
+import berlin.yuna.typemap.model.TypeList;
+import berlin.yuna.typemap.model.TypeMap;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JsonDecoderTest {
+
+    private static final String COMPLEX_JSON = "{\"name\":\"neo\",\"nested\":{\"level\":1,\"list\":[{\"x\":1},2,true]},\"tags\":[\"a\",\"b\"]}";
+
+    @Test
+    void shouldStreamAllOverloads() throws Exception {
+        final Path file = Files.createTempFile("stream-json", ".json");
+        Files.writeString(file, COMPLEX_JSON, StandardCharsets.UTF_8);
+        final File asFile = file.toFile();
+        final URI uri = file.toUri();
+        final URL url = uri.toURL();
+
+        assertComplex(JsonDecoder.streamJson(new ByteArrayInputStream(COMPLEX_JSON.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8));
+        assertComplex(JsonDecoder.streamJson(new ByteArrayInputStream(COMPLEX_JSON.getBytes(StandardCharsets.UTF_8))));
+        assertComplex(JsonDecoder.streamJson(COMPLEX_JSON, StandardCharsets.UTF_8));
+        assertComplex(JsonDecoder.streamJson(COMPLEX_JSON));
+        assertComplex(JsonDecoder.streamJson(new StringBuilder(COMPLEX_JSON), StandardCharsets.UTF_8));
+        assertComplex(JsonDecoder.streamJson(new StringBuilder(COMPLEX_JSON)));
+        assertComplex(JsonDecoder.streamJson(file, StandardCharsets.UTF_8));
+        assertComplex(JsonDecoder.streamJson(file));
+        assertComplex(JsonDecoder.streamJson(asFile, StandardCharsets.UTF_8));
+        assertComplex(JsonDecoder.streamJson(asFile));
+        assertComplex(JsonDecoder.streamJson(uri, StandardCharsets.UTF_8));
+        assertComplex(JsonDecoder.streamJson(uri));
+        assertComplex(JsonDecoder.streamJson(url, StandardCharsets.UTF_8));
+        assertComplex(JsonDecoder.streamJson(url));
+    }
+
+    @Test
+    void shouldStreamArrayWithIndexKeys() throws Exception {
+        final String array = "[{\"x\":1},2,true]";
+        try (final Stream<Pair<String, Object>> stream = JsonDecoder.streamJson(array)) {
+            final Map<Object, Object> result = stream.collect(Collectors.toMap(Pair::key, Pair::value));
+            assertThat(result.keySet()).containsExactly("0", "1", "2");
+            assertThat((LinkedTypeMap) result.get("0")).containsEntry("x", 1L);
+            assertThat(result).containsEntry("1", 2L);
+            assertThat(result).containsEntry("2", true);
+        }
+    }
+
+    @Test
+    void shouldReturnEmptyOnNullOrWhitespace() throws Exception {
+        assertThat(JsonDecoder.streamJson((InputStream) null)).isEmpty();
+        try (final Stream<Pair<String, Object>> stream = JsonDecoder.streamJson("   ")) {
+            assertThat(stream).isEmpty();
+        }
+    }
+
+    @Test
+    void shouldFailOnInvalidJson() {
+        assertThatThrownBy(() -> JsonDecoder.streamJson("oops").toList())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("Expected JSON object or array");
+        assertThatThrownBy(() -> JsonDecoder.streamJson("{\"a\":1").toList())
+            .isInstanceOf(IllegalStateException.class);
+    }
+
+    private void assertComplex(final Stream<Pair<Object, Object>> stream) {
+        final TypeMap data = new TypeMap();
+        stream.forEach(p -> data.put(p.key(), p.value()));
+
+
+        assertThat(data).containsKeys("name", "nested", "tags");
+        assertThat(data).containsEntry("name", "neo");
+        assertThat(data.get("nested")).isInstanceOf(LinkedTypeMap.class);
+        final LinkedTypeMap nested = (LinkedTypeMap) data.get("nested");
+        assertThat(nested).containsEntry("level", 1L);
+        assertThat(nested.get("list")).isInstanceOf(TypeList.class);
+        final TypeList list = (TypeList) nested.get("list");
+        assertThat(list).hasSize(3);
+        assertThat((LinkedTypeMap) list.get(0)).containsEntry("x", 1L);
+        assertThat(list).contains(2L, true);
+        assertThat(data.get("tags")).isInstanceOf(TypeList.class);
+        assertThat((TypeList) data.get("tags")).containsExactly("a", "b");
+    }
+}

--- a/src/test/java/berlin/yuna/typemap/logic/JsonDecoderTest.java
+++ b/src/test/java/berlin/yuna/typemap/logic/JsonDecoderTest.java
@@ -53,7 +53,7 @@ class JsonDecoderTest {
     void shouldStreamArrayWithIndexKeys() throws Exception {
         final String array = "[{\"x\":1},2,true]";
         try (final Stream<Pair<String, Object>> stream = JsonDecoder.streamJson(array)) {
-            final Map<Object, Object> result = stream.collect(Collectors.toMap(Pair::key, Pair::value));
+            final Map<String, Object> result = stream.collect(Collectors.toMap(Pair::key, Pair::value));
             assertThat(result.keySet()).containsExactly("0", "1", "2");
             assertThat((LinkedTypeMap) result.get("0")).containsEntry("x", 1L);
             assertThat(result).containsEntry("1", 2L);
@@ -78,9 +78,11 @@ class JsonDecoderTest {
             .isInstanceOf(IllegalStateException.class);
     }
 
-    private void assertComplex(final Stream<Pair<Object, Object>> stream) {
+    private void assertComplex(final Stream<Pair<String, Object>> stream) {
         final TypeMap data = new TypeMap();
-        stream.forEach(p -> data.put(p.key(), p.value()));
+        try (final Stream<Pair<String, Object>> closeable = stream) {
+            closeable.forEach(p -> data.put(p.key(), p.value()));
+        }
 
 
         assertThat(data).containsKeys("name", "nested", "tags");

--- a/src/test/java/berlin/yuna/typemap/logic/JsonEncoderTest.java
+++ b/src/test/java/berlin/yuna/typemap/logic/JsonEncoderTest.java
@@ -69,7 +69,7 @@ class JsonEncoderTest {
         assertThat((JsonDecoder.jsonOf(jsonString))).isEqualTo(expectedString);
         assertThat(JsonDecoder.listOf(jsonString)).isEqualTo(singletonList(expectedString));
         assertThat(JsonDecoder.mapOf(jsonString)).containsEntry("", expectedString);
-        assertThat(JsonDecoder.jsonTypeOf(jsonString).get(String.class,0)).isEqualTo(expectedString);
+        assertThat(JsonDecoder.typeOf(jsonString).get(String.class,0)).isEqualTo(expectedString);
 
         // STREAM PATHS
         try (InputStream mapStream = new ByteArrayInputStream(jsonString.getBytes(UTF_8));

--- a/src/test/java/berlin/yuna/typemap/logic/JsonEncoderTest.java
+++ b/src/test/java/berlin/yuna/typemap/logic/JsonEncoderTest.java
@@ -3,9 +3,13 @@ package berlin.yuna.typemap.logic;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.IOException;
 import java.util.*;
 
 import static berlin.yuna.typemap.logic.JsonEncoder.toJson;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -65,5 +69,16 @@ class JsonEncoderTest {
         assertThat(JsonDecoder.jsonListOf(jsonString)).isEqualTo(singletonList(expectedString));
         assertThat(JsonDecoder.jsonMapOf(jsonString)).containsEntry("", expectedString);
         assertThat(JsonDecoder.jsonTypeOf(jsonString).get(String.class,0)).isEqualTo(expectedString);
+
+        // STREAM PATHS
+        try (InputStream mapStream = new ByteArrayInputStream(jsonString.getBytes(UTF_8));
+             InputStream listStream = new ByteArrayInputStream(jsonString.getBytes(UTF_8));
+             InputStream valueStream = new ByteArrayInputStream(jsonString.getBytes(UTF_8))) {
+            assertThat(JsonDecoder.jsonMapOf(mapStream)).containsEntry("", expectedString);
+            assertThat(JsonDecoder.jsonListOf(listStream)).containsExactly(expectedString);
+            assertThat(JsonDecoder.jsonOf(valueStream)).isEqualTo(expectedString);
+        } catch (final IOException e) {
+            throw new IllegalStateException(e);
+        }
     }
 }

--- a/src/test/java/berlin/yuna/typemap/logic/JsonEncoderTest.java
+++ b/src/test/java/berlin/yuna/typemap/logic/JsonEncoderTest.java
@@ -36,47 +36,47 @@ class JsonEncoderTest {
         jsonString = "{}";
         assertThat(toJson(null)).isEqualTo(jsonString);
         assertThat(JsonDecoder.jsonOf(jsonString)).isNull();
-        assertThat(JsonDecoder.jsonListOf(jsonString)).isEmpty();
-        assertThat(JsonDecoder.jsonMapOf(jsonString)).isEmpty();
+        assertThat(JsonDecoder.listOf(jsonString)).isEmpty();
+        assertThat(JsonDecoder.mapOf(jsonString)).isEmpty();
 
         // MAP
         jsonString = "{2:\"Fri Jan 15 08:00:00 UTC 2027\"}";
         assertThat(toJson(inputMap)).isEqualTo(jsonString);
         assertThat((Map<Object, Object>) JsonDecoder.jsonOf(jsonString)).containsExactlyInAnyOrderEntriesOf(outputMap);
-        assertThat(JsonDecoder.jsonListOf(jsonString)).containsExactly(outputMap);
-        assertThat(JsonDecoder.jsonMapOf(jsonString)).containsExactlyInAnyOrderEntriesOf(outputMap);
+        assertThat(JsonDecoder.listOf(jsonString)).containsExactly(outputMap);
+        assertThat(JsonDecoder.mapOf(jsonString)).containsExactlyInAnyOrderEntriesOf(outputMap);
 
         // COLLECTION
         jsonString = "[\"BB\",1,true,null,1.2]";
         final List<Object> expectedCollection = asList("BB", 1L, true, null, 1.2);
         assertThat(toJson(expectedCollection)).isEqualTo(jsonString);
         assertThat((Collection<Object>) JsonDecoder.jsonOf(jsonString)).isEqualTo(expectedCollection);
-        assertThat(JsonDecoder.jsonListOf(jsonString)).isEqualTo(expectedCollection);
-        assertThat((Collection<Object>) JsonDecoder.jsonMapOf(jsonString).get("")).isEqualTo(expectedCollection);
+        assertThat(JsonDecoder.listOf(jsonString)).isEqualTo(expectedCollection);
+        assertThat((Collection<Object>) JsonDecoder.mapOf(jsonString).get("")).isEqualTo(expectedCollection);
 
         // ARRAY
         jsonString = "[\"BB\",1,true]";
         final List<Object> expectedArray = asList("BB", 1L, true);
         assertThat(toJson(new Object[]{"BB", 1, true, null})).isEqualTo(jsonString);
         assertThat((Collection<Object>) JsonDecoder.jsonOf(jsonString)).isEqualTo(expectedArray);
-        assertThat(JsonDecoder.jsonListOf(jsonString)).isEqualTo(expectedArray);
-        assertThat(JsonDecoder.jsonMapOf(jsonString)).containsEntry("", expectedArray);
+        assertThat(JsonDecoder.listOf(jsonString)).isEqualTo(expectedArray);
+        assertThat(JsonDecoder.mapOf(jsonString)).containsEntry("", expectedArray);
 
         // String
         jsonString = "{\"HH,II,\\n\"}";
         final String expectedString = "HH,II,\n";
         assertThat(toJson(expectedString)).isEqualTo(jsonString);
         assertThat((JsonDecoder.jsonOf(jsonString))).isEqualTo(expectedString);
-        assertThat(JsonDecoder.jsonListOf(jsonString)).isEqualTo(singletonList(expectedString));
-        assertThat(JsonDecoder.jsonMapOf(jsonString)).containsEntry("", expectedString);
+        assertThat(JsonDecoder.listOf(jsonString)).isEqualTo(singletonList(expectedString));
+        assertThat(JsonDecoder.mapOf(jsonString)).containsEntry("", expectedString);
         assertThat(JsonDecoder.jsonTypeOf(jsonString).get(String.class,0)).isEqualTo(expectedString);
 
         // STREAM PATHS
         try (InputStream mapStream = new ByteArrayInputStream(jsonString.getBytes(UTF_8));
              InputStream listStream = new ByteArrayInputStream(jsonString.getBytes(UTF_8));
              InputStream valueStream = new ByteArrayInputStream(jsonString.getBytes(UTF_8))) {
-            assertThat(JsonDecoder.jsonMapOf(mapStream)).containsEntry("", expectedString);
-            assertThat(JsonDecoder.jsonListOf(listStream)).containsExactly(expectedString);
+            assertThat(JsonDecoder.mapOf(mapStream)).containsEntry("", expectedString);
+            assertThat(JsonDecoder.listOf(listStream)).containsExactly(expectedString);
             assertThat(JsonDecoder.jsonOf(valueStream)).isEqualTo(expectedString);
         } catch (final IOException e) {
             throw new IllegalStateException(e);

--- a/src/test/java/berlin/yuna/typemap/logic/JsonEncoderTest.java
+++ b/src/test/java/berlin/yuna/typemap/logic/JsonEncoderTest.java
@@ -7,6 +7,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.IOException;
 import java.util.*;
+import java.util.stream.Stream;
 
 import static berlin.yuna.typemap.logic.JsonEncoder.toJson;
 import static java.nio.charset.StandardCharsets.UTF_8;

--- a/src/test/java/berlin/yuna/typemap/logic/XmlDecoderTest.java
+++ b/src/test/java/berlin/yuna/typemap/logic/XmlDecoderTest.java
@@ -1,15 +1,24 @@
 package berlin.yuna.typemap.logic;
 
 import berlin.yuna.typemap.model.Pair;
+import berlin.yuna.typemap.model.LinkedTypeMap;
+import berlin.yuna.typemap.model.TypeMap;
 import berlin.yuna.typemap.model.TypeList;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -57,5 +66,135 @@ class XmlDecoderTest {
         assertThat(XmlDecoder.xmlTypeOf((File) null)).isEqualTo(new TypeList());
         assertThat(XmlDecoder.xmlTypeOf((String) null)).isEqualTo(new TypeList());
         assertThat(XmlDecoder.xmlTypeOf((InputStream) null)).isEqualTo(new TypeList());
+    }
+
+    @Test
+    void shouldRoundTripXmlMapWithMultipleEntries() {
+        final LinkedTypeMap input = new LinkedTypeMap();
+        final TypeList items = new TypeList();
+        items.add(new Pair<>("item", "a"));
+        input.put("root", items);
+        input.put("extra", "value");
+
+        final String xml = XmlEncoder.toXmlMap(input);
+        final LinkedTypeMap output = TypeMap.fromXml(xml);
+
+        assertThat(output).isEqualTo(input);
+    }
+
+    @Test
+    void shouldStreamXmlObject() {
+        final String xml = """
+            <root>
+              <item id="1"><name>neo</name><flags><flag>true</flag><flag>false</flag></flags></item>
+              <item id="2"><name>trinity</name><flags/></item>
+            </root>
+            """;
+        try (final Stream<Pair<String, Object>> stream = XmlDecoder.streamXmlObject(xml, StandardCharsets.UTF_8)) {
+            final Map<String, Object> result = stream.collect(Collectors.toMap(Pair::key, Pair::value));
+            assertThat(result).containsOnlyKeys("root");
+            final TypeList rootList = (TypeList) result.get("root");
+            assertThat(rootList).hasSize(2);
+            final Pair<?, ?> first = (Pair<?, ?>) rootList.get(0);
+            assertThat(first.getKey()).isEqualTo("item");
+            final TypeList firstItem = (TypeList) first.getValue();
+            assertThat(firstItem.get(String.class, "@id")).isEqualTo("1");
+            assertThat(firstItem.get(String.class, "name", 0)).isEqualTo("neo");
+            final Pair<?, ?> flags = (Pair<?, ?>) firstItem.get(2);
+            final TypeList flagList = (TypeList) flags.getValue();
+            assertThat(flagList).hasSize(2);
+            final Pair<?, ?> firstFlag = (Pair<?, ?>) flagList.get(0);
+            final Pair<?, ?> secondFlag = (Pair<?, ?>) flagList.get(1);
+            assertThat(firstFlag.getKey()).isEqualTo("flag");
+            assertThat(((TypeList) firstFlag.getValue()).get(0)).isEqualTo("true");
+            assertThat(secondFlag.getKey()).isEqualTo("flag");
+            assertThat(((TypeList) secondFlag.getValue()).get(0)).isEqualTo("false");
+        }
+    }
+
+    @Test
+    void shouldStreamXmlHandlesEmptyAndText() {
+        final String xml = "<root><empty/><text> hi </text></root>";
+        try (final Stream<Pair<String, Object>> stream = XmlDecoder.streamXmlObject(xml)) {
+            final Map<String, Object> result = stream.collect(Collectors.toMap(Pair::key, Pair::value));
+            final TypeList root = (TypeList) result.get("root");
+            assertThat(((Pair<?, ?>) root.get(0)).getValue()).isInstanceOf(TypeList.class);
+            final Object textValue = ((Pair<?, ?>) root.get(1)).getValue();
+            assertThat(textValue).isInstanceOf(TypeList.class);
+            assertThat(((TypeList) textValue).get(0)).isEqualTo("hi");
+        }
+    }
+
+    @Test
+    void shouldStreamXmlAcrossOverloads() throws Exception {
+        final String xml = "<root><item id=\"1\">alpha</item><item id=\"2\">beta</item></root>";
+        final Path file = Files.createTempFile("stream-xml", ".xml");
+        Files.writeString(file, xml, StandardCharsets.UTF_8);
+        final File asFile = file.toFile();
+        final java.net.URI uri = file.toUri();
+        final java.net.URL url = uri.toURL();
+
+        final Map<String, Object> expected = collect(XmlDecoder.streamXmlObject(xml));
+        final Map<String, Object> fromBytes = collect(XmlDecoder.streamXmlObject(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8));
+        final Map<String, Object> fromDefault = collect(XmlDecoder.streamXmlObject(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))));
+        final Map<String, Object> fromFile = collect(XmlDecoder.streamXmlObject(file));
+        final Map<String, Object> fromFileWithCharset = collect(XmlDecoder.streamXmlObject(file, StandardCharsets.UTF_8));
+        final Map<String, Object> fromAsFile = collect(XmlDecoder.streamXmlObject(asFile));
+        final Map<String, Object> fromAsFileCharset = collect(XmlDecoder.streamXmlObject(asFile, StandardCharsets.UTF_8));
+        final Map<String, Object> fromUri = collect(XmlDecoder.streamXmlObject(uri));
+        final Map<String, Object> fromUriCharset = collect(XmlDecoder.streamXmlObject(uri, StandardCharsets.UTF_8));
+        final Map<String, Object> fromUrl = collect(XmlDecoder.streamXmlObject(url));
+        final Map<String, Object> fromUrlCharset = collect(XmlDecoder.streamXmlObject(url, StandardCharsets.UTF_8));
+
+        assertThat(expected).isEqualTo(fromBytes)
+            .isEqualTo(fromDefault)
+            .isEqualTo(fromFile)
+            .isEqualTo(fromFileWithCharset)
+            .isEqualTo(fromAsFile)
+            .isEqualTo(fromAsFileCharset)
+            .isEqualTo(fromUri)
+            .isEqualTo(fromUriCharset)
+            .isEqualTo(fromUrl)
+            .isEqualTo(fromUrlCharset);
+        assertThat(((TypeList) expected.get("root"))).hasSize(2);
+    }
+
+    @Test
+    @EnabledIfSystemProperty(named = "perf", matches = "true")
+    void benchmarkStreamXmlObject() {
+        final String xml = largeXml(2000);
+        final AtomicInteger count = new AtomicInteger();
+        final long memBefore = usedMemoryKb();
+        final long start = System.nanoTime();
+        try (final Stream<Pair<String, Object>> stream = XmlDecoder.streamXmlObject(xml, StandardCharsets.UTF_8)) {
+            stream.forEach(p -> {
+                count.incrementAndGet();
+                assertThat(p.key()).isEqualTo("root");
+            });
+        }
+        final long durationMs = (System.nanoTime() - start) / 1_000_000;
+        final long memDelta = usedMemoryKb() - memBefore;
+        System.out.printf("benchmarkStreamXmlObject elements=%d took=%dms memDelta=%dKB%n", count.get(), durationMs, memDelta);
+        assertThat(count.get()).isEqualTo(1);
+    }
+
+    private static String largeXml(final int size) {
+        final StringBuilder builder = new StringBuilder(size * 48).append("<root>");
+        for (int i = 0; i < size; i++) {
+            builder.append("<item id=\"").append(i).append("\"><name>n").append(i).append("</name><value>").append(i * 2).append("</value></item>");
+        }
+        builder.append("</root>");
+        return builder.toString();
+    }
+
+    private static long usedMemoryKb() {
+        final Runtime runtime = Runtime.getRuntime();
+        return (runtime.totalMemory() - runtime.freeMemory()) / 1024;
+    }
+
+    private static Map<String, Object> collect(final Stream<Pair<String, Object>> stream) {
+        try (Stream<Pair<String, Object>> s = stream) {
+            return s.collect(Collectors.toMap(Pair::key, Pair::value));
+        }
     }
 }

--- a/src/test/java/berlin/yuna/typemap/logic/XmlDecoderTest.java
+++ b/src/test/java/berlin/yuna/typemap/logic/XmlDecoderTest.java
@@ -81,10 +81,10 @@ class XmlDecoderTest {
 
         assertThat(output).containsOnlyKeys("root");
         final TypeList rootList = (TypeList) output.get("root");
-        final Pair<?, ?> rootPair = rootList.stream()
+        final Pair<?, ?> itemPair = rootList.stream()
             .filter(Pair.class::isInstance)
             .map(Pair.class::cast)
-            .filter(pair -> "root".equals(pair.getKey()))
+            .filter(pair -> "item".equals(pair.getKey()))
             .findFirst()
             .orElseThrow();
         final Pair<?, ?> extraPair = rootList.stream()
@@ -93,7 +93,6 @@ class XmlDecoderTest {
             .filter(pair -> "extra".equals(pair.getKey()))
             .findFirst()
             .orElseThrow();
-        final Pair<?, ?> itemPair = (Pair<?, ?>) ((TypeList) rootPair.getValue()).get(0);
         assertThat(itemPair.getKey()).isEqualTo("item");
         assertThat(((TypeList) itemPair.getValue()).get(0)).isEqualTo("a");
         assertThat(((TypeList) extraPair.getValue()).get(0)).isEqualTo("value");

--- a/src/test/java/berlin/yuna/typemap/logic/XmlDecoderTest.java
+++ b/src/test/java/berlin/yuna/typemap/logic/XmlDecoderTest.java
@@ -79,7 +79,24 @@ class XmlDecoderTest {
         final String xml = XmlEncoder.toXmlMap(input);
         final LinkedTypeMap output = TypeMap.fromXml(xml);
 
-        assertThat(output).isEqualTo(input);
+        assertThat(output).containsOnlyKeys("root");
+        final TypeList rootList = (TypeList) output.get("root");
+        final Pair<?, ?> rootPair = rootList.stream()
+            .filter(Pair.class::isInstance)
+            .map(Pair.class::cast)
+            .filter(pair -> "root".equals(pair.getKey()))
+            .findFirst()
+            .orElseThrow();
+        final Pair<?, ?> extraPair = rootList.stream()
+            .filter(Pair.class::isInstance)
+            .map(Pair.class::cast)
+            .filter(pair -> "extra".equals(pair.getKey()))
+            .findFirst()
+            .orElseThrow();
+        final Pair<?, ?> itemPair = (Pair<?, ?>) ((TypeList) rootPair.getValue()).get(0);
+        assertThat(itemPair.getKey()).isEqualTo("item");
+        assertThat(((TypeList) itemPair.getValue()).get(0)).isEqualTo("a");
+        assertThat(((TypeList) extraPair.getValue()).get(0)).isEqualTo("value");
     }
 
     @Test

--- a/src/test/java/berlin/yuna/typemap/model/CompatLoadTest.java
+++ b/src/test/java/berlin/yuna/typemap/model/CompatLoadTest.java
@@ -1,0 +1,75 @@
+package berlin.yuna.typemap.model;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnabledIfSystemProperty(named = "perf", matches = "true")
+class CompatLoadTest {
+
+    @Test
+    void benchmarkTypeMapConstructor() {
+        final String payload = largeObjectJson(4000);
+        final long memBefore = usedMemoryKb();
+        final long start = System.nanoTime();
+
+        final TypeMap map = new TypeMap(payload);
+
+        final long durationMs = (System.nanoTime() - start) / 1_000_000;
+        final long memDelta = usedMemoryKb() - memBefore;
+
+        assertThat(map).hasSize(4000);
+        assertThat(map.get("k0")).isInstanceOf(Map.class);
+        assertThat(((Map<?, ?>) map.get("k0")).get("idx")).isEqualTo(0L);
+        System.out.printf("compatTypeMapConstructor entries=%d took=%dms memDelta=%dKB%n", map.size(), durationMs, memDelta);
+    }
+
+    @Test
+    void benchmarkTypeListConstructor() {
+        final String payload = largeArrayJson(5000);
+        final long memBefore = usedMemoryKb();
+        final long start = System.nanoTime();
+
+        final TypeList list = new TypeList(payload);
+
+        final long durationMs = (System.nanoTime() - start) / 1_000_000;
+        final long memDelta = usedMemoryKb() - memBefore;
+
+        assertThat(list).hasSize(5000);
+        assertThat(list.get(0)).isInstanceOf(Map.class);
+        assertThat(((Map<?, ?>) list.get(0)).get("id")).isEqualTo(0L);
+        System.out.printf("compatTypeListConstructor items=%d took=%dms memDelta=%dKB%n", list.size(), durationMs, memDelta);
+    }
+
+    private static String largeArrayJson(final int size) {
+        final StringBuilder sb = new StringBuilder(size * 64).append('[');
+        for (int i = 0; i < size; i++) {
+            if (i > 0) {
+                sb.append(',');
+            }
+            sb.append("{\"id\":").append(i).append(",\"name\":\"n").append(i).append("\",\"flags\":[true,false,true]}");
+        }
+        sb.append(']');
+        return sb.toString();
+    }
+
+    private static String largeObjectJson(final int size) {
+        final StringBuilder sb = new StringBuilder(size * 48).append('{');
+        for (int i = 0; i < size; i++) {
+            if (i > 0) {
+                sb.append(',');
+            }
+            sb.append("\"k").append(i).append("\":{\"idx\":").append(i).append(",\"nested\":{\"v\":").append(i * 2).append("}}");
+        }
+        sb.append('}');
+        return sb.toString();
+    }
+
+    private static long usedMemoryKb() {
+        final Runtime runtime = Runtime.getRuntime();
+        return (runtime.totalMemory() - runtime.freeMemory()) / 1024;
+    }
+}

--- a/src/test/java/berlin/yuna/typemap/model/PairTest.java
+++ b/src/test/java/berlin/yuna/typemap/model/PairTest.java
@@ -22,6 +22,16 @@ class PairTest {
     }
 
     @Test
+    void shouldExposeTypeInfoConvenience() {
+        final Pair<String, Object> numberPair = new Pair<>("num", "42");
+        final Pair<String, Object> flagPair = new Pair<>("flag", "true");
+        assertThat(numberPair.asInt()).isEqualTo(42);
+        assertThat(numberPair.valueType().asLong()).isEqualTo(42L);
+        assertThat(flagPair.asBoolean()).isTrue();
+        assertThat(flagPair.asBoolean("value")).isTrue();
+    }
+
+    @Test
     void TestEquals() {
         final Pair<Integer, String> pair1 = new Pair<>(111, "AA");
         final Pair<Integer, String> pair2 = new Pair<>(111, "BB");

--- a/src/test/java/berlin/yuna/typemap/model/PairTest.java
+++ b/src/test/java/berlin/yuna/typemap/model/PairTest.java
@@ -2,6 +2,8 @@ package berlin.yuna.typemap.model;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class PairTest {
@@ -29,6 +31,19 @@ class PairTest {
         assertThat(numberPair.valueType().asLong()).isEqualTo(42L);
         assertThat(flagPair.asBoolean()).isTrue();
         assertThat(flagPair.asBoolean("value")).isTrue();
+    }
+
+    @Test
+    void shouldSupportTypeInfoLookups() {
+        final Pair<String, Object> pair = new Pair<>("list", List.of("a", "b"));
+        assertThat(pair.valueInfo().asList(String.class)).containsExactly("a", "b");
+        assertThat(pair.typeListOpt().value()).isNull();
+        assertThat(pair.typeMapOpt().value()).isNull();
+        assertThat(pair.asOpt("key").value()).isEqualTo("list");
+        assertThat(pair.asOpt("value").value()).isEqualTo(List.of("a", "b"));
+        final Pair<String, Object> viaAddR = new Pair<String, Object>(null, null).addR("k", null).addR(null, "v");
+        assertThat(viaAddR.getKey()).isEqualTo("k");
+        assertThat(viaAddR.getValue()).isEqualTo("v");
     }
 
     @Test

--- a/src/test/java/berlin/yuna/typemap/model/PairTest.java
+++ b/src/test/java/berlin/yuna/typemap/model/PairTest.java
@@ -32,6 +32,17 @@ class PairTest {
     }
 
     @Test
+    void shouldConvertToTargetTypes() {
+        final Pair<Object, Object> pair = new Pair<>("1", "true");
+        final Pair<Integer, Boolean> converted = pair.to(Integer.class, Boolean.class);
+        assertThat(converted.key()).isEqualTo(1);
+        assertThat(converted.value()).isTrue();
+        final Pair<String, Object> widened = pair.to(String.class, Object.class);
+        assertThat(widened.key()).isEqualTo("1");
+        assertThat(widened.value()).isEqualTo("true");
+    }
+
+    @Test
     void TestEquals() {
         final Pair<Integer, String> pair1 = new Pair<>(111, "AA");
         final Pair<Integer, String> pair2 = new Pair<>(111, "BB");

--- a/src/test/java/berlin/yuna/typemap/model/TypeListTest.java
+++ b/src/test/java/berlin/yuna/typemap/model/TypeListTest.java
@@ -15,7 +15,7 @@ import java.time.*;
 import java.util.*;
 import java.util.stream.Stream;
 
-import static berlin.yuna.typemap.logic.JsonDecoder.streamJson;
+import static berlin.yuna.typemap.logic.JsonDecoder.streamJsonArray;
 import static berlin.yuna.typemap.logic.TypeConverter.collectionOf;
 import static berlin.yuna.typemap.logic.TypeConverter.convertObj;
 import static berlin.yuna.typemap.model.TypeMapTest.TEST_TIME;
@@ -282,21 +282,21 @@ class TypeListTest {
     @Test
     void shouldStreamJsonArray() throws Exception {
         final String json = "[1,\"alpha\",true]";
-        try (Stream<Pair<String, Object>> stream = streamJson(json)) {
-            final List<Pair<String, Object>> entries = stream.toList();
-            final List<String> keys = entries.stream().map(Pair::key).toList();
+        try (Stream<Pair<Integer, Object>> stream = streamJsonArray(json)) {
+            final List<Pair<Integer, Object>> entries = stream.toList();
+            final List<Integer> keys = entries.stream().map(Pair::key).toList();
             final List<Object> values = entries.stream().map(Pair::value).toList();
             final List<Object> expected = Arrays.asList(1L, "alpha", true);
-            assertThat(keys).containsExactly("0", "1", "2");
+            assertThat(keys).containsExactly(0, 1, 2);
             assertThat(values).containsExactlyElementsOf(expected);
         }
         try (InputStream in = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
-             Stream<Pair<String, Object>> stream = streamJson(in)) {
-            final List<Pair<String, Object>> entries = stream.toList();
-            final List<String> keys = entries.stream().map(Pair::key).toList();
+             Stream<Pair<Integer, Object>> stream = streamJsonArray(in)) {
+            final List<Pair<Integer, Object>> entries = stream.toList();
+            final List<Integer> keys = entries.stream().map(Pair::key).toList();
             final List<Object> values = entries.stream().map(Pair::value).toList();
             final List<Object> expected = Arrays.asList(1L, "alpha", true);
-            assertThat(keys).containsExactly("0", "1", "2");
+            assertThat(keys).containsExactly(0, 1, 2);
             assertThat(values).containsExactlyElementsOf(expected);
         }
     }

--- a/src/test/java/berlin/yuna/typemap/model/TypeListTest.java
+++ b/src/test/java/berlin/yuna/typemap/model/TypeListTest.java
@@ -280,6 +280,30 @@ class TypeListTest {
     }
 
     @Test
+    void shouldReadJsonFromCharSequenceAndPath() throws Exception {
+        final String json = "[\"x\",{\"y\":1}]";
+        final Path jsonPath = Files.createTempFile("typelist-json", ".json");
+        Files.writeString(jsonPath, json);
+        assertThat(TypeList.fromJson((CharSequence) json)).containsExactly("x", Map.of("y", 1L));
+        try (InputStream in = Files.newInputStream(jsonPath)) {
+            assertThat(TypeList.fromJson(in)).hasSize(2);
+        }
+    }
+
+    @Test
+    void shouldHandleEmptyOrNullJsonGracefully() {
+        assertThat(TypeList.fromJson((String) null)).isEmpty();
+        assertThat(TypeList.fromJson((CharSequence) null)).isEmpty();
+    }
+
+    @Test
+    void shouldHandleEmptyArgsAndJson() {
+        assertThat(TypeList.fromArgs((String) null)).isEmpty();
+        assertThat(TypeList.fromArgs((CharSequence) null)).isEmpty();
+        assertThat(TypeList.fromJson("")).isEmpty();
+    }
+
+    @Test
     void shouldStreamJsonArray() throws Exception {
         final String json = "[1,\"alpha\",true]";
         try (Stream<Pair<Integer, Object>> stream = streamJsonArray(json)) {

--- a/src/test/java/berlin/yuna/typemap/model/TypeListTest.java
+++ b/src/test/java/berlin/yuna/typemap/model/TypeListTest.java
@@ -15,6 +15,7 @@ import java.time.*;
 import java.util.*;
 import java.util.stream.Stream;
 
+import static berlin.yuna.typemap.logic.JsonDecoder.streamJson;
 import static berlin.yuna.typemap.logic.TypeConverter.collectionOf;
 import static berlin.yuna.typemap.logic.TypeConverter.convertObj;
 import static berlin.yuna.typemap.model.TypeMapTest.TEST_TIME;
@@ -276,6 +277,28 @@ class TypeListTest {
         assertThat((TypeSet) argsMap.get("name")).contains("neo");
         assertThat(TypeList.fromArgs("--name=neo").get(0)).isInstanceOf(Map.class);
         assertThat(TypeList.fromArgs((CharSequence) "--name=neo").get(0)).isInstanceOf(Map.class);
+    }
+
+    @Test
+    void shouldStreamJsonArray() throws Exception {
+        final String json = "[1,\"alpha\",true]";
+        try (Stream<Pair<Object, Object>> stream = streamJson(json)) {
+            final List<Pair<String, Object>> entries = stream.toList();
+            final List<String> keys = entries.stream().map(Pair::key).toList();
+            final List<Object> values = entries.stream().map(Pair::value).toList();
+            final List<Object> expected = Arrays.asList(1L, "alpha", true);
+            assertThat(keys).containsExactly("0", "1", "2");
+            assertThat(values).containsExactlyElementsOf(expected);
+        }
+        try (InputStream in = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
+             Stream<Pair<Object, Object>> stream = streamJson(in)) {
+            final List<Pair<String, Object>> entries = stream.toList();
+            final List<String> keys = entries.stream().map(Pair::key).toList();
+            final List<Object> values = entries.stream().map(Pair::value).toList();
+            final List<Object> expected = Arrays.asList(1L, "alpha", true);
+            assertThat(keys).containsExactly("0", "1", "2");
+            assertThat(values).containsExactlyElementsOf(expected);
+        }
     }
 
     @Test

--- a/src/test/java/berlin/yuna/typemap/model/TypeListTest.java
+++ b/src/test/java/berlin/yuna/typemap/model/TypeListTest.java
@@ -282,7 +282,7 @@ class TypeListTest {
     @Test
     void shouldStreamJsonArray() throws Exception {
         final String json = "[1,\"alpha\",true]";
-        try (Stream<Pair<Object, Object>> stream = streamJson(json)) {
+        try (Stream<Pair<String, Object>> stream = streamJson(json)) {
             final List<Pair<String, Object>> entries = stream.toList();
             final List<String> keys = entries.stream().map(Pair::key).toList();
             final List<Object> values = entries.stream().map(Pair::value).toList();
@@ -291,7 +291,7 @@ class TypeListTest {
             assertThat(values).containsExactlyElementsOf(expected);
         }
         try (InputStream in = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
-             Stream<Pair<Object, Object>> stream = streamJson(in)) {
+             Stream<Pair<String, Object>> stream = streamJson(in)) {
             final List<Pair<String, Object>> entries = stream.toList();
             final List<String> keys = entries.stream().map(Pair::key).toList();
             final List<Object> values = entries.stream().map(Pair::value).toList();

--- a/src/test/java/berlin/yuna/typemap/model/TypeListTest.java
+++ b/src/test/java/berlin/yuna/typemap/model/TypeListTest.java
@@ -326,6 +326,18 @@ class TypeListTest {
     }
 
     @Test
+    void shouldStreamPairsFromTypeListInstance() {
+        final TypeList list = new TypeList();
+        list.addAll(List.of("x", 2));
+        assertThat(list.streamPairs().toList())
+            .extracting(Pair::key, Pair::value)
+            .containsExactly(org.assertj.core.groups.Tuple.tuple(0, "x"), org.assertj.core.groups.Tuple.tuple(1, 2));
+        assertThat(list.streamPairs(String.class).toList())
+            .extracting(Pair::value)
+            .containsExactly("x", "2");
+    }
+
+    @Test
     void shouldSupportArgsFileAndStream() throws Exception {
         final Path argsPath = Files.createTempFile("typelist-args", ".txt");
         Files.writeString(argsPath, "--name=trinity -count=3");

--- a/src/test/java/berlin/yuna/typemap/model/TypeMapTest.java
+++ b/src/test/java/berlin/yuna/typemap/model/TypeMapTest.java
@@ -28,7 +28,7 @@ import java.util.stream.Stream;
 import berlin.yuna.typemap.model.Type;
 
 import static berlin.yuna.typemap.logic.JsonDecoder.jsonTypeOf;
-import static berlin.yuna.typemap.logic.JsonDecoder.streamJson;
+import static berlin.yuna.typemap.logic.JsonDecoder.streamJsonObject;
 import static berlin.yuna.typemap.logic.TypeConverter.collectionOf;
 import static berlin.yuna.typemap.logic.TypeConverter.convertObj;
 import static berlin.yuna.typemap.logic.XmlDecoder.xmlTypeOf;
@@ -789,12 +789,12 @@ public class TypeMapTest {
     @Test
     void shouldStreamJsonObjectEntries() throws Exception {
         final String json = "{\"a\":1,\"b\":\"c\"}";
-        try (Stream<Pair<String, Object>> stream = streamJson(json)) {
+        try (Stream<Pair<String, Object>> stream = streamJsonObject(json)) {
             final LinkedHashMap<String, Object> map = stream.collect(LinkedHashMap::new, (m, p) -> m.put(p.getKey(), p.getValue()), Map::putAll);
             assertThat(map).containsExactly(entry("a", 1L), entry("b", "c"));
         }
         try (InputStream stream = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
-             Stream<Pair<String, Object>> s = streamJson(stream)) {
+             Stream<Pair<String, Object>> s = streamJsonObject(stream)) {
             final LinkedHashMap<String, Object> map = s.collect(LinkedHashMap::new, (m, p) -> m.put(p.getKey(), p.getValue()), Map::putAll);
             assertThat(map).containsExactly(entry("a", 1L), entry("b", "c"));
         }
@@ -803,7 +803,7 @@ public class TypeMapTest {
     @Test
     void shouldExposeTypeInfoConvenienceOnStreamedPairs() throws Exception {
         final String json = "{\"num\":\"7\",\"flag\":\"true\"}";
-        try (Stream<Pair<String, Object>> stream = streamJson(json)) {
+        try (Stream<Pair<String, Object>> stream = streamJsonObject(json)) {
             final LinkedHashMap<String, Object> converted = stream.collect(LinkedHashMap::new, (m, p) -> {
                 if ("num".equals(p.key())) {
                     m.put(p.key(), p.valueType().asInt());

--- a/src/test/java/berlin/yuna/typemap/model/TypeMapTest.java
+++ b/src/test/java/berlin/yuna/typemap/model/TypeMapTest.java
@@ -32,7 +32,6 @@ import java.util.stream.Stream;
 
 import berlin.yuna.typemap.model.Type;
 
-import static berlin.yuna.typemap.logic.JsonDecoder.jsonTypeOf;
 import static berlin.yuna.typemap.logic.JsonDecoder.streamJsonObject;
 import static berlin.yuna.typemap.logic.TypeConverter.collectionOf;
 import static berlin.yuna.typemap.logic.TypeConverter.convertObj;
@@ -456,7 +455,7 @@ public class TypeMapTest {
 
     @Test
     void addTest() {
-        final TypeInfo<?> jsonMap = jsonTypeOf("{\n"
+        final TypeInfo<?> jsonMap = JsonDecoder.typeOf("{\n"
             + "  \"outerMap\": {\n"
             + "    \"times\": {\n"
             + "      \"timestamp1\": 1800000000000,\n"
@@ -476,7 +475,7 @@ public class TypeMapTest {
 
     @Test
     void setTest() {
-        final TypeInfo<?> jsonMap = jsonTypeOf("{\n"
+        final TypeInfo<?> jsonMap = JsonDecoder.typeOf("{\n"
             + "  \"outerMap\": {\n"
             + "    \"times\": {\n"
             + "      \"timestamp1\": 1800000000000,\n"
@@ -498,7 +497,7 @@ public class TypeMapTest {
 
     @Test
     void putTest() {
-        final TypeInfo<?> jsonMap = jsonTypeOf("{\n"
+        final TypeInfo<?> jsonMap = JsonDecoder.typeOf("{\n"
             + "  \"outerMap\": {\n"
             + "    \"times\": {\n"
             + "      \"timestamp1\": 1800000000000,\n"
@@ -521,7 +520,7 @@ public class TypeMapTest {
 
     @Test
     void containsTest() {
-        final TypeInfo<?> jsonMap = jsonTypeOf("{\n"
+        final TypeInfo<?> jsonMap = JsonDecoder.typeOf("{\n"
             + "  \"outerMap\": {\n"
             + "    \"times\": {\n"
             + "      \"timestamp1\": 1800000000000,\n"
@@ -569,7 +568,7 @@ public class TypeMapTest {
             + "  }\n"
             + "}";
 
-        final TypeInfo<?> jsonMap = jsonTypeOf(jsonInput);
+        final TypeInfo<?> jsonMap = JsonDecoder.typeOf(jsonInput);
         final LinkedTypeMap map1 = jsonMap.asMap("outerMap", "times");
         final TestEnum testEnum = jsonMap.asList("outerMap", "myList").get(TestEnum.class, 0);
 

--- a/src/test/java/berlin/yuna/typemap/model/TypeMapTest.java
+++ b/src/test/java/berlin/yuna/typemap/model/TypeMapTest.java
@@ -789,12 +789,12 @@ public class TypeMapTest {
     @Test
     void shouldStreamJsonObjectEntries() throws Exception {
         final String json = "{\"a\":1,\"b\":\"c\"}";
-        try (Stream<Pair<Object, Object>> stream = streamJson(json)) {
+        try (Stream<Pair<String, Object>> stream = streamJson(json)) {
             final LinkedHashMap<String, Object> map = stream.collect(LinkedHashMap::new, (m, p) -> m.put(p.getKey(), p.getValue()), Map::putAll);
             assertThat(map).containsExactly(entry("a", 1L), entry("b", "c"));
         }
         try (InputStream stream = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
-             Stream<Pair<Object, Object>> s = streamJson(stream)) {
+             Stream<Pair<String, Object>> s = streamJson(stream)) {
             final LinkedHashMap<String, Object> map = s.collect(LinkedHashMap::new, (m, p) -> m.put(p.getKey(), p.getValue()), Map::putAll);
             assertThat(map).containsExactly(entry("a", 1L), entry("b", "c"));
         }
@@ -803,11 +803,7 @@ public class TypeMapTest {
     @Test
     void shouldExposeTypeInfoConvenienceOnStreamedPairs() throws Exception {
         final String json = "{\"num\":\"7\",\"flag\":\"true\"}";
-        try (Stream<Pair<String, Object>> stream = streamJson(json).map(objectObjectPair -> {
-            String s = objectObjectPair.valueAs(String.class);
-            final Pair<String, Object> bb = objectObjectPair.to(String.class, Object.class);
-            return objectObjectPair;
-        })) {
+        try (Stream<Pair<String, Object>> stream = streamJson(json)) {
             final LinkedHashMap<String, Object> converted = stream.collect(LinkedHashMap::new, (m, p) -> {
                 if ("num".equals(p.key())) {
                     m.put(p.key(), p.valueType().asInt());


### PR DESCRIPTION
### Types of changes

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [x] Breaking change (fix or feature that would cause existing functionality to change)

  ## Motivation

  Expanded streaming coverage to ensure the new stream-based JSON/XML paths behave correctly with deeply nested data, unicode, nulls, and XML-derived structures. This guards against regressions after the streaming refactors.

  ## Changes

  - Added complex object/array streaming cases to JsonDecoderTest (nested objects/arrays, unicode, nulls, mixed primitives).
  - Added nested XML streaming scenario in TypeMapTest to validate streamPairs traversal of attributes, nested lists/maps, and role extraction without full materialization.
  - Adjusted assertions to align with current XML decoding shape (attributes and text nodes wrapped in TypeList).

  ## Success Check

  - ./mvnw -q test passes.
